### PR TITLE
Refactor kernel

### DIFF
--- a/blackjax/ns/adaptive.py
+++ b/blackjax/ns/adaptive.py
@@ -201,7 +201,9 @@ def nss(
     def step(**kwargs):
         def proposal_distribution(key):
             return ravel_fn(predict_fn(key, **kwargs))
-        return build_slice_kernel(proposal_distribution, stepper)
+        def constraint_fn(x):
+            return loglikelihood_fn(x) - kwargs["logL0"]
+        return build_slice_kernel(proposal_distribution, stepper, constraint_fn)
 
     kernel = build_kernel(
         logprior_fn,

--- a/blackjax/ns/adaptive.py
+++ b/blackjax/ns/adaptive.py
@@ -9,8 +9,8 @@ from blackjax.ns.base import NSInfo, NSState
 from blackjax.ns.base import build_kernel as base_ns
 from blackjax.ns.base import delete_fn
 from blackjax.ns.base import init as init_base
-from blackjax.ns.hr_slice import build_slice_kernel as slice_kernel
-from blackjax.ns.hr_slice import init as slice_init
+from blackjax.mcmc.hr_slice import build_kernel as build_slice_kernel
+from blackjax.mcmc.hr_slice import init as slice_init
 from blackjax.smc.inner_kernel_tuning import StateWithParameterOverride
 from blackjax.smc.tuning.from_particles import particles_covariance_matrix
 from blackjax.types import ArrayLikeTree, ArrayTree, PRNGKey
@@ -201,7 +201,7 @@ def nss(
     def step(**kwargs):
         def proposal_distribution(key):
             return ravel_fn(predict_fn(key, **kwargs))
-        return slice_kernel(proposal_distribution, stepper)
+        return build_slice_kernel(proposal_distribution, stepper)
 
     kernel = build_kernel(
         logprior_fn,

--- a/blackjax/ns/adaptive.py
+++ b/blackjax/ns/adaptive.py
@@ -48,7 +48,7 @@ def build_kernel(
         Function that takes an array of log likelihoods and marks particles for deletion and updates.
     mcmc_step_fn:
         The initialisation of the transition kernel, should take as parameters.
-        kernel = mcmc_step_fn(logprior, loglikelihood, logL0 (likelihood threshold), **mcmc_parameter_update_fn())
+        kernel = mcmc_step_fn(**mcmc_parameter_update_fn())
     mcmc_init_fn
         A callable that initializes the inner kernel
     mcmc_parameter_update_fn : Callable[[NSState, NSInfo], Dict[str, ArrayTree]]
@@ -198,10 +198,10 @@ def nss(
     def parameter_update_fn(state, _):
         return train_fn(state.particles)
 
-    def step(logprior, loglikelihood, logL0, **kwargs):
+    def step(**kwargs):
         def proposal_distribution(key):
             return ravel_fn(predict_fn(key, **kwargs))
-        return slice_kernel(logprior, loglikelihood, logL0, proposal_distribution, stepper)
+        return slice_kernel(proposal_distribution, stepper)
 
     kernel = build_kernel(
         logprior_fn,

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -92,7 +92,7 @@ def build_kernel(
 
         new_pos = jax.tree.map(lambda x: x[live_idx], state.particles)
 
-        mcmc_parameters["constraint"] = lambda x: loglikelihood_fn(x) - logL0
+        mcmc_parameters["logL0"] = logL0
         kernel = mcmc_step_fn(**mcmc_parameters)
         rng_key, sample_key = jax.random.split(rng_key)
 


### PR DESCRIPTION
**PR Title:** Refactor: Generalize Hit-and-Run Slice Sampler and move to MCMC module

**Description:**

This PR refactors the Hit-and-Run Slice Sampler (`hr_slice`) by:
1.  **Moving it** from the `blackjax.ns` (Nested Sampling) module to `blackjax.mcmc`, acknowledging it as a general-purpose MCMC kernel.
2.  **Generalizing its functionality** to sample from a target density subject to an arbitrary constraint function, rather than being tightly coupled to the Nested Sampling specific constraint (`loglikelihood > logL0`).

The primary goal is to improve modularity, making the `hr_slice` sampler reusable outside the context of Nested Sampling and clarifying the separation of concerns between the MCMC kernel and its application within NS.

**Key Changes:**

1.  **File Relocation:**
    *   `blackjax/ns/hr_slice.py` renamed to `blackjax/mcmc/hr_slice.py`.

2.  **`mcmc.hr_slice` Generalization:**
    *   `SliceState`: Renamed `loglikelihood` field to `constraint`. This field now stores the output of the user-provided `constraint_fn`.
    *   `init`: Now takes an optional `constraint_fn` (defaults to `lambda x: jnp.inf`, meaning no constraint) instead of `loglikelihood`. Initializes the new `constraint` state field.
    *   `build_kernel` (formerly `build_slice_kernel`):
        *   No longer takes `logprior_fn`, `loglikelihood_fn`, or `logL0` as arguments during kernel *building*.
        *   Now takes a `constraint: Callable` argument, which defines the region to sample within (`constraint(x) > 0`).
    *   `kernel` (returned by `build_kernel`):
        *   Now takes `logdensity_fn` as an argument at *runtime*. This function defines the target density for the vertical slice (`logdensity(x) >= log_uniform_draw`).
        *   Uses the provided `logdensity_fn` for the vertical slice condition.
        *   Uses the `constraint` function (passed during `build_kernel`) for the horizontal slice acceptance (`constraint(x) > 0`).
    *   `horizontal_slice_proposal`: Logic updated to check `logprob(x) >= logprob0` (vertical slice) and `constraint(x) > 0` (user constraint). Returns the `constraint` value in the `SliceState`.
    *   Added `constraint_default` helper.

3.  **Nested Sampling (`ns`) Adaptation:**
    *   `ns/adaptive.py`:
        *   Updated imports to use `blackjax.mcmc.hr_slice`.
        *   The local `step` function now builds the slice kernel constraint dynamically using the NS `loglikelihood_fn` and the current `logL0` from `**kwargs`: `constraint_fn = lambda x: loglikelihood_fn(x) - logL0`.
        *   Calls the refactored `build_slice_kernel` with the appropriate arguments (proposal, stepper, dynamic constraint).
    *   `ns/base.py`:
        *   The MCMC kernel (`mcmc_step_fn`, which is the `step` function from `adaptive.py`) is now called with `**mcmc_parameters` (which includes `logL0`).
        *   The inner MCMC kernel call (`num_mcmc_steps_kernel`) passes `logprior_fn` as the `logdensity_fn` argument to the slice kernel (for the vertical slice step). The likelihood constraint is handled implicitly via the `constraint_fn` built inside `mcmc_step_fn`.
        *   Reconstructs the `logL` value for updated particles using `new_state.constraint + logL0`, correctly interpreting the constraint value returned by the generalized sampler in the NS context.

**Motivation:**

*   **Modularity:** Decouples the slice sampling algorithm from its specific use case within Nested Sampling.
*   **Reusability:** Allows the Hit-and-Run Slice Sampler to be used as a general MCMC kernel for sampling densities subject to arbitrary constraints (e.g., parameter bounds, feasibility regions).
*   **Clarity:** Makes the code structure cleaner by placing general MCMC methods in the `mcmc` module. The NS module now clearly *uses* an MCMC kernel rather than *containing* it.

**Impact:**

*   The external interface of the Nested Sampling kernels remains largely unchanged.
*   The internal interface of the Hit-and-Run Slice Sampler has changed significantly, requiring callers (like the NS module) to adapt how they provide the target density and constraints.
*   Users directly importing `hr_slice` from `blackjax.ns` will need to update their imports and potentially adapt their usage to the new interface.

**Review Focus:**

*   Verify the correctness of the generalized condition check in `horizontal_slice_proposal`.
*   Ensure the adaptation in `ns/base.py` and `ns/adaptive.py` correctly reconstructs the original Nested Sampling behavior using the new generalized slice sampler interface (specifically how `logprior_fn`, `loglikelihood_fn`, and `logL0` are now handled).
*   Confirm the new `SliceState` and function signatures are used consistently.