### PR TITLE
Improve direction proposal stability

### DIFF
--- a/blackjax/mcmc/ss.py
+++ b/blackjax/mcmc/ss.py
@@ -387,32 +387,36 @@ def default_stepper_fn(x: ArrayTree, d: ArrayTree, t: float) -> ArrayTree:
 
 
 def sample_direction_from_covariance(
-    rng_key: PRNGKey, cov: Array, inv_cov: Array
+    rng_key: PRNGKey, cov: Array, chol: Array
 ) -> Array:
     """Generates a random direction vector, normalized, from a multivariate Gaussian.
 
-    This function samples a direction `d` from a zero-mean multivariate Gaussian
-    distribution with covariance matrix `cov`, and then normalizes `d` to be a
-    unit vector with respect to the Mahalanobis norm defined by `inv(cov)`.
-    That is, `d_normalized^T @ inv(cov) @ d_normalized = 1`.
+    This function generates a direction vector uniformly distributed on a hypersphere
+    by using the mathematical simplification:
+    1. Sample from standard multivariate normal N(0, I)
+    2. Normalize to unit vector (uniform on hypersphere)  
+    3. Transform by S^(1/2) where S is the covariance matrix
+
+    This is equivalent to sampling from N(0, S) and normalizing by Mahalanobis norm
+    but is more numerically stable and efficient.
 
     Parameters
     ----------
     rng_key
         A JAX PRNG key.
     cov
-        The covariance matrix for the multivariate Gaussian distribution from which
-        the initial direction is sampled. Assumed to be a 2D array.
+        The covariance matrix (unused in simplified version, kept for compatibility).
+    chol
+        The square root of the covariance matrix (Cholesky factor).
 
     Returns
     -------
     Array
         A normalized direction vector (1D array).
     """
-    d = jax.random.multivariate_normal(rng_key, mean=jnp.zeros(cov.shape[0]), cov=cov)
-    d *= 2
-    norm = jnp.sqrt(jnp.einsum("...i,...ij,...j", d, inv_cov, d))
-    d = d / norm[..., None]
+    z = jax.random.normal(rng_key, shape=(cov.shape[0],))
+    u = z / jnp.linalg.norm(z)
+    d = chol @ u
     return d
 
 

--- a/blackjax/mcmc/ss.py
+++ b/blackjax/mcmc/ss.py
@@ -410,6 +410,7 @@ def sample_direction_from_covariance(
         A normalized direction vector (1D array).
     """
     d = jax.random.multivariate_normal(rng_key, mean=jnp.zeros(cov.shape[0]), cov=cov)
+    d *= 2
     norm = jnp.sqrt(jnp.einsum("...i,...ij,...j", d, inv_cov, d))
     d = d / norm[..., None]
     return d

--- a/blackjax/mcmc/ss.py
+++ b/blackjax/mcmc/ss.py
@@ -386,7 +386,9 @@ def default_stepper_fn(x: ArrayTree, d: ArrayTree, t: float) -> ArrayTree:
     return jax.tree.map(lambda x, d: x + t * d, x, d)
 
 
-def sample_direction_from_covariance(rng_key: PRNGKey, cov: Array) -> Array:
+def sample_direction_from_covariance(
+    rng_key: PRNGKey, cov: Array, inv_cov: Array
+) -> Array:
     """Generates a random direction vector, normalized, from a multivariate Gaussian.
 
     This function samples a direction `d` from a zero-mean multivariate Gaussian
@@ -408,8 +410,7 @@ def sample_direction_from_covariance(rng_key: PRNGKey, cov: Array) -> Array:
         A normalized direction vector (1D array).
     """
     d = jax.random.multivariate_normal(rng_key, mean=jnp.zeros(cov.shape[0]), cov=cov)
-    invcov = jnp.linalg.inv(cov)
-    norm = jnp.sqrt(jnp.einsum("...i,...ij,...j", d, invcov, d))
+    norm = jnp.sqrt(jnp.einsum("...i,...ij,...j", d, inv_cov, d))
     d = d / norm[..., None]
     return d
 

--- a/blackjax/ns/nss.py
+++ b/blackjax/ns/nss.py
@@ -132,7 +132,7 @@ def compute_covariance_from_particles(
     """
     cov_matrix = jnp.atleast_2d(particles_covariance_matrix(state.particles))
     cov_matrix *= cov_matrix.shape[0] + 2
-    chol_matrix = jnp.linalg.cholesky(cov_matrix)
+    chol_matrix = jnp.linalg.cholesky(cov_matrix, lower=True)
     single_particle = get_first_row(state.particles)
     _, unravel_fn = ravel_pytree(single_particle)
     cov_pytree = jax.vmap(unravel_fn)(cov_matrix)

--- a/blackjax/ns/nss.py
+++ b/blackjax/ns/nss.py
@@ -136,6 +136,7 @@ def compute_covariance_from_particles(
         This means each leaf of `cov_pytree` will have a shape `(D, *leaf_original_dims)`.
     """
     cov_matrix = jnp.atleast_2d(particles_covariance_matrix(state.particles))
+    cov_matrix *= cov_matrix.shape[0] + 2
     cho = jnp.linalg.cholesky(cov_matrix)
     inv_cov_matrix = cho_solve((cho, True), jnp.eye(cho.shape[0]))
     single_particle = get_first_row(state.particles)


### PR DESCRIPTION
This PR refactors the Nested Slice Sampler (`nss`) to improve performance and numerical stability when sampling proposal directions.

- The inverse of the particle covariance matrix is now pre-computed in `compute_covariance_from_particles` and passed to the direction sampling function.
- This avoids a repeated and expensive call to `jnp.linalg.inv` on every sampling step.
- The inverse calculation now uses the more numerically stable Cholesky decomposition (`cho_solve`).
- The covariance estimator is also updated with a new scaling factor.