### PR TITLE
Add init factory for NSS and SS

### DIFF
--- a/blackjax/mcmc/ss.py
+++ b/blackjax/mcmc/ss.py
@@ -108,6 +108,7 @@ def init(
 
 def build_kernel(
     stepper_fn: Callable,
+    init_fn: Callable = init,
     max_steps: int = 10,
     max_shrinkage: int = 100,
 ) -> Callable:
@@ -151,7 +152,7 @@ def build_kernel(
 
         def slicer(t) -> tuple[SliceState, SliceInfo]:
             x, step_accepted = stepper_fn(state.position, d, t)
-            new_state = init(x, logdensity_fn, constraint_fn)
+            new_state = init_fn(x, logdensity_fn, constraint_fn)
             constraints_ok = jnp.all(
                 jnp.where(
                     strict,
@@ -265,6 +266,7 @@ def horizontal_slice(
 def build_hrss_kernel(
     generate_slice_direction_fn: Callable,
     stepper_fn: Callable,
+    init_fn: Callable = init,
     max_steps: int = 10,
 ) -> Callable:
     """Build a Hit-and-Run Slice Sampling kernel.
@@ -292,7 +294,7 @@ def build_hrss_kernel(
         A kernel function that takes a PRNG key, the current `SliceState`, and
         the log-density function, and returns a new `SliceState` and `SliceInfo`.
     """
-    slice_kernel = build_kernel(stepper_fn, max_steps)
+    slice_kernel = build_kernel(stepper_fn, init_fn=init_fn, max_steps=max_steps)
 
     def kernel(
         rng_key: PRNGKey, state: SliceState, logdensity_fn: Callable

--- a/blackjax/ns/adaptive.py
+++ b/blackjax/ns/adaptive.py
@@ -74,8 +74,6 @@ def init(
 
 
 def build_kernel(
-    logprior_fn: Callable,
-    loglikelihood_fn: Callable,
     delete_fn: Callable,
     inner_kernel: Callable,
     update_inner_kernel_params_fn: Callable[
@@ -119,8 +117,6 @@ def build_kernel(
     """
 
     base_kernel = base_build_kernel(
-        logprior_fn,
-        loglikelihood_fn,
         delete_fn,
         inner_kernel,
     )

--- a/blackjax/ns/adaptive.py
+++ b/blackjax/ns/adaptive.py
@@ -36,8 +36,7 @@ __all__ = ["init", "build_kernel"]
 
 def init(
     particles: ArrayLikeTree,
-    logprior_fn: Callable,
-    loglikelihood_fn: Callable,
+    init_state_fn: Callable,
     loglikelihood_birth: Array = -jnp.nan,
     update_inner_kernel_params_fn: Optional[Callable] = None,
 ) -> NSState:
@@ -66,7 +65,7 @@ def init(
     NSState
         The initial state of the Nested Sampler.
     """
-    state = base_init(particles, logprior_fn, loglikelihood_fn, loglikelihood_birth)
+    state = base_init(particles, init_state_fn, loglikelihood_birth)
     if update_inner_kernel_params_fn is not None:
         inner_kernel_params = update_inner_kernel_params_fn(state, None, {})
         state = state._replace(inner_kernel_params=inner_kernel_params)

--- a/blackjax/ns/adaptive.py
+++ b/blackjax/ns/adaptive.py
@@ -48,10 +48,8 @@ def init(
         An initial set of particles (PyTree of arrays) drawn from the prior
         distribution. The leading dimension of each leaf array must be equal to
         the number of particles.
-    loglikelihood_fn
-        A function that computes the log-likelihood of a single particle.
-    logprior_fn
-        A function that computes the log-prior of a single particle.
+    init_state_fn
+        A function that initializes a StateWithLogLikelihood from particles.
     loglikelihood_birth
         The initial log-likelihood birth threshold. Defaults to -NaN, which
         implies no initial likelihood constraint beyond the prior.
@@ -88,10 +86,6 @@ def build_kernel(
 
     Parameters
     ----------
-    logprior_fn
-        A function that computes the log-prior probability of a single particle.
-    loglikelihood_fn
-        A function that computes the log-likelihood of a single particle.
     delete_fn
         this particle deletion function has the signature
         `(rng_key, current_state) -> (dead_idx, target_update_idx, start_idx)`
@@ -100,7 +94,7 @@ def build_kernel(
         for new particle generation.
     inner_kernel
         This kernel function has the signature
-        `(rng_key, inner_state, logprior_fn, loglikelihood_fn, loglikelihood_0, inner_kernel_params) -> (new_inner_state, inner_info)`,
+        `(rng_keys, inner_state, loglikelihood_0, inner_kernel_params) -> (new_inner_state, inner_info)`,
         and is used to generate new particles.
     update_inner_kernel_params_fn
         A function that takes the `NSState`, `NSInfo` from the completed NS

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -105,11 +105,10 @@ class NSInfo(NamedTuple):
     loglikelihood: Array  # The log-likelihood of the particles
     loglikelihood_birth: Array  # The log-likelihood threshold at particle birth
     logprior: Array  # The log-prior density of the particles
-    inner_kernel_states: NamedTuple
-    inner_kernel_info: NamedTuple  # Information from the inner kernel update step
+    update_info: NamedTuple
 
 
-class PartitionedState(NamedTuple):
+class StateWithLogLikelihood(NamedTuple):
     """State container that partitions out the loglikelihood and logprior.
 
     This intermediate construction wraps around the usual State of an MCMC chain
@@ -136,17 +135,10 @@ class PartitionedState(NamedTuple):
     loglikelihood: Array  # Log-likelihood values for particles in the inner kernel
 
 
-class PartitionedInfo(NamedTuple):
-    """A wrapper around a Paritioned transition kernel info"""
-
-    transition_state: PartitionedState
-    transition_info: NamedTuple
-
-
-def init_partitioned_state(
+def init_state_with_likelihood(
     position: ArrayLikeTree, logprior_fn: Callable, loglikelihood_fn: Callable
-) -> PartitionedState:
-    """Initializes a PartitionedState for the inner kernel.
+) -> StateWithLogLikelihood:
+    """Initializes a StateWithLoglikelihood for the inner kernel.
 
     Parameters
     ----------
@@ -165,7 +157,7 @@ def init_partitioned_state(
     """
     logprior_values = logprior_fn(position)
     loglikelihood_values = loglikelihood_fn(position)
-    return PartitionedState(position, logprior_values, loglikelihood_values)
+    return StateWithLogLikelihood(position, logprior_values, loglikelihood_values)
 
 
 def init(
@@ -289,8 +281,8 @@ def build_kernel(
         particles = jax.tree.map(lambda x: x[start_idx], state.particles)
         logprior = state.logprior[start_idx]
         loglikelihood = state.loglikelihood[start_idx]
-        inner_state = PartitionedState(particles, logprior, loglikelihood)
-        new_inner_state, inner_info = inner_kernel(
+        inner_state = StateWithLogLikelihood(particles, logprior, loglikelihood)
+        new_state, update_info = inner_kernel(
             sample_keys,
             inner_state,
             logprior_fn,
@@ -303,15 +295,15 @@ def build_kernel(
         particles = jax.tree_util.tree_map(
             lambda p, n: p.at[target_update_idx].set(n),
             state.particles,
-            new_inner_state.position,
+            new_state.position,
         )
         loglikelihood = state.loglikelihood.at[target_update_idx].set(
-            new_inner_state.loglikelihood
+            new_state.loglikelihood
         )
         loglikelihood_birth = state.loglikelihood_birth.at[target_update_idx].set(
             loglikelihood_0
         )
-        logprior = state.logprior.at[target_update_idx].set(new_inner_state.logdensity)
+        logprior = state.logprior.at[target_update_idx].set(new_state.logdensity)
         pid = state.pid.at[target_update_idx].set(state.pid[start_idx])
 
         # Update the run-time information
@@ -336,8 +328,7 @@ def build_kernel(
             dead_loglikelihood,
             dead_loglikelihood_birth,
             dead_logprior,
-            inner_info.transition_state,
-            inner_info.transition_info,
+            update_info,
         )
         return state, info
 

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -135,10 +135,10 @@ class StateWithLogLikelihood(NamedTuple):
     loglikelihood: Array  # Log-likelihood values for particles in the inner kernel
 
 
-def init_state_with_likelihood(
+def init_state_strategy(
     position: ArrayLikeTree, logprior_fn: Callable, loglikelihood_fn: Callable
 ) -> StateWithLogLikelihood:
-    """Initializes a StateWithLoglikelihood for the inner kernel.
+    """The default initialisation strategy for each state.
 
     Parameters
     ----------
@@ -162,8 +162,7 @@ def init_state_with_likelihood(
 
 def init(
     particles: ArrayLikeTree,
-    logprior_fn: Callable,
-    loglikelihood_fn: Callable,
+    init_state_fn: Callable,
     loglikelihood_birth: Array = -jnp.nan,
     logX: Optional[Array] = 0.0,
     logZ: Optional[Array] = -jnp.inf,
@@ -193,9 +192,10 @@ def init(
     NSState
         The initial state of the Nested Sampler.
     """
-    loglikelihood = loglikelihood_fn(particles)
+    state = init_state_fn(particles)
+    loglikelihood = state.loglikelihood
     loglikelihood_birth = loglikelihood_birth * jnp.ones_like(loglikelihood)
-    logprior = logprior_fn(particles)
+    logprior = state.logdensity
     pid = jnp.arange(len(loglikelihood), dtype=jnp.int32)
     dtype = loglikelihood.dtype
     logX = jnp.array(logX, dtype=dtype)

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -216,8 +216,6 @@ def init(
 
 
 def build_kernel(
-    logprior_fn: Callable,
-    loglikelihood_fn: Callable,
     delete_fn: Callable,
     inner_kernel: Callable,
 ) -> Callable:
@@ -285,8 +283,6 @@ def build_kernel(
         new_inner_state, inner_update_info = inner_kernel(
             sample_keys,
             inner_state,
-            logprior_fn,
-            loglikelihood_fn,
             loglikelihood_0,
             state.inner_kernel_params,
         )

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -131,7 +131,7 @@ class PartitionedState(NamedTuple):
     """
 
     position: ArrayLikeTree  # Current positions of particles in the inner kernel
-    logprior: Array  # Log-prior values for particles in the inner kernel
+    logdensity: Array  # Log-prior values for particles in the inner kernel
     loglikelihood: Array  # Log-likelihood values for particles in the inner kernel
 
 
@@ -164,6 +164,31 @@ class PartitionedInfo(NamedTuple):
     logprior: ArrayTree
     loglikelihood: ArrayTree
     info: NamedTuple
+
+
+def init_partitioned_state(
+    position: ArrayLikeTree, logprior_fn: Callable, loglikelihood_fn: Callable
+) -> PartitionedState:
+    """Initializes a PartitionedState for the inner kernel.
+
+    Parameters
+    ----------
+    position
+        A PyTree of arrays representing the initial positions of the particles.
+        Each leaf array has a leading dimension corresponding to the number of particles.
+    logprior
+        A function that computes the log-prior density for a single particle.
+    loglikelihood
+        A function that computes the log-likelihood for a single particle.
+
+    Returns
+    -------
+    PartitionedState
+        The initialized state containing positions, log-prior, and log-likelihood.
+    """
+    logprior_values = logprior_fn(position)
+    loglikelihood_values = loglikelihood_fn(position)
+    return PartitionedState(position, logprior_values, loglikelihood_values)
 
 
 def init(
@@ -309,7 +334,7 @@ def build_kernel(
         loglikelihood_birth = state.loglikelihood_birth.at[target_update_idx].set(
             loglikelihood_0
         )
-        logprior = state.logprior.at[target_update_idx].set(new_inner_state.logprior)
+        logprior = state.logprior.at[target_update_idx].set(new_inner_state.logdensity)
         pid = state.pid.at[target_update_idx].set(state.pid[start_idx])
 
         # Update the run-time information
@@ -395,7 +420,9 @@ def update_ns_runtime_info(
 ) -> tuple[Array, Array, Array]:
     num_particles = len(loglikelihood)
     num_deleted = len(dead_loglikelihood)
-    num_live = jnp.arange(num_particles, num_particles - num_deleted, -1, dtype=loglikelihood.dtype)
+    num_live = jnp.arange(
+        num_particles, num_particles - num_deleted, -1, dtype=loglikelihood.dtype
+    )
     delta_logX = -1 / num_live
     logX = logX + jnp.cumsum(delta_logX)
     log_delta_X = logX + jnp.log(1 - jnp.exp(delta_logX))

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -105,6 +105,7 @@ class NSInfo(NamedTuple):
     loglikelihood: Array  # The log-likelihood of the particles
     loglikelihood_birth: Array  # The log-likelihood threshold at particle birth
     logprior: Array  # The log-prior density of the particles
+    inner_kernel_states: NamedTuple
     inner_kernel_info: NamedTuple  # Information from the inner kernel update step
 
 
@@ -136,26 +137,7 @@ class PartitionedState(NamedTuple):
 
 
 class PartitionedInfo(NamedTuple):
-    """Records paritioned state information
-
-    Attributes
-    ----------
-    position
-        A PyTree of arrays representing the final positions after the transition step.
-        Structure matches the input particle positions.
-    logprior
-        An array of log-prior density values at the final positions.
-        Kept separate to support posterior repartitioning schemes.
-        Shape: (n_particles,)
-    loglikelihood
-        An array of log-likelihood values at the final positions.
-        Kept separate to support posterior repartitioning schemes.
-        Shape: (n_particles,)
-    info
-        Additional transition-specific diagnostic information from the step.
-        The content and structure depend on the specific transition implementation
-        (e.g., acceptance rates, step sizes, number of evaluations, etc.).
-    """
+    """A wrapper around a Paritioned transition kernel info"""
 
     transition_state: PartitionedState
     transition_info: NamedTuple
@@ -354,7 +336,8 @@ def build_kernel(
             dead_loglikelihood,
             dead_loglikelihood_birth,
             dead_logprior,
-            inner_info,
+            inner_info.transition_state,
+            inner_info.transition_info,
         )
         return state, info
 

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -136,10 +136,7 @@ class PartitionedState(NamedTuple):
 
 
 class PartitionedInfo(NamedTuple):
-    """Transition information that additionally records a partitioned loglikelihood
-    and logprior.
-
-    See PartitionedState
+    """Records paritioned state information
 
     Attributes
     ----------
@@ -160,10 +157,8 @@ class PartitionedInfo(NamedTuple):
         (e.g., acceptance rates, step sizes, number of evaluations, etc.).
     """
 
-    position: ArrayTree
-    logprior: ArrayTree
-    loglikelihood: ArrayTree
-    info: NamedTuple
+    transition_state: PartitionedState
+    transition_info: NamedTuple
 
 
 def init_partitioned_state(

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -175,10 +175,8 @@ def init(
         An initial set of particles (PyTree of arrays) drawn from the prior
         distribution. The leading dimension of each leaf array must be equal to
         the number of particles.
-    logprior_fn
-        A function that computes the log-prior of a single particle.
-    loglikelihood_fn
-        A function that computes the log-likelihood of a single particle.
+    init_state_fn
+        A function that initializes a StateWithLogLikelihood from particles.
     loglikelihood_birth
         The initial log-likelihood birth threshold. Defaults to -NaN, which
         implies no initial likelihood constraint beyond the prior.
@@ -241,10 +239,6 @@ def build_kernel(
 
     Parameters
     ----------
-    logprior_fn
-        A function that computes the log-prior probability of a single particle.
-    loglikelihood_fn
-        A function that computes the log-likelihood of a single particle.
     delete_fn
         this particle deletion function has the signature
         `(rng_key, current_state) -> (dead_idx, target_update_idx, start_idx)`
@@ -253,7 +247,7 @@ def build_kernel(
         for new particle generation.
     inner_kernel
         This kernel function has the signature
-        `(rng_key, inner_state, logprior_fn, loglikelihood_fn, loglikelihood_0, params) -> (new_inner_state, inner_info)`,
+        `(rng_keys, inner_state, loglikelihood_0, params) -> (new_inner_state, inner_info)`,
         and is used to generate new particles.
 
     Returns

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -95,7 +95,7 @@ class NSInfo(NamedTuple):
         The birth log-likelihood thresholds of the dead particles.
     logprior
         The log-prior values of the dead particles.
-    inner_kernel_info
+    update_info
         A NamedTuple (or any PyTree) containing information from the update step
         (inner kernel) used to generate new live particles. The content
         depends on the specific inner kernel used.
@@ -282,7 +282,7 @@ def build_kernel(
         logprior = state.logprior[start_idx]
         loglikelihood = state.loglikelihood[start_idx]
         inner_state = StateWithLogLikelihood(particles, logprior, loglikelihood)
-        new_state, update_info = inner_kernel(
+        new_inner_state, inner_update_info = inner_kernel(
             sample_keys,
             inner_state,
             logprior_fn,
@@ -295,15 +295,15 @@ def build_kernel(
         particles = jax.tree_util.tree_map(
             lambda p, n: p.at[target_update_idx].set(n),
             state.particles,
-            new_state.position,
+            new_inner_state.position,
         )
         loglikelihood = state.loglikelihood.at[target_update_idx].set(
-            new_state.loglikelihood
+            new_inner_state.loglikelihood
         )
         loglikelihood_birth = state.loglikelihood_birth.at[target_update_idx].set(
             loglikelihood_0
         )
-        logprior = state.logprior.at[target_update_idx].set(new_state.logdensity)
+        logprior = state.logprior.at[target_update_idx].set(new_inner_state.logdensity)
         pid = state.pid.at[target_update_idx].set(state.pid[start_idx])
 
         # Update the run-time information
@@ -328,7 +328,7 @@ def build_kernel(
             dead_loglikelihood,
             dead_loglikelihood_birth,
             dead_logprior,
-            update_info,
+            inner_update_info,
         )
         return state, info
 

--- a/blackjax/ns/from_mcmc.py
+++ b/blackjax/ns/from_mcmc.py
@@ -1,0 +1,42 @@
+from functools import partial
+from typing import NamedTuple
+
+import jax
+
+
+class MCMCUpdateInfo(NamedTuple):
+    """Thin layer to hold all the info pertaining to the update step."""
+
+    mcmc_states: NamedTuple
+    mcmc_infos: NamedTuple
+
+
+def update_with_mcmc_take_last(
+    constrained_mcmc_step_fn,
+    num_mcmc_steps,
+):
+    """An update strategy for NS that uses MCMC to update the particles."""
+
+    def update_function(
+        rng_key, state, logprior_fn, loglikelihood_fn, loglikelihood_0, step_parameters
+    ):
+        shared_mcmc_step_fn = partial(
+            constrained_mcmc_step_fn,
+            logprior_fn=logprior_fn,
+            loglikelihood_fn=loglikelihood_fn,
+            loglikelihood_0=loglikelihood_0,
+            **step_parameters,
+        )
+
+        def mcmc_kernel(rng_key, state):
+            def body_fn(state, rng_key):
+                new_state, info = shared_mcmc_step_fn(rng_key, state)
+                return new_state, (new_state, info)
+
+            keys = jax.random.split(rng_key, num_mcmc_steps)
+            final_state, infos = jax.lax.scan(body_fn, state, keys)
+            return final_state, MCMCUpdateInfo(infos[0], infos[1])
+
+        return jax.vmap(mcmc_kernel, in_axes=(0, 0))(rng_key, state)
+
+    return update_function

--- a/blackjax/ns/from_mcmc.py
+++ b/blackjax/ns/from_mcmc.py
@@ -18,7 +18,9 @@ def update_with_mcmc_take_last(
     constrained_mcmc_step_fn,
     num_mcmc_steps,
 ):
-    """An update strategy for NS that uses MCMC to update the particles."""
+    """An update strategy for NS that uses MCMC to update the particles.
+    For now we will not keep the states as they will be too large to store.
+    """
 
     def update_function(rng_key, state, loglikelihood_0, step_parameters):
         shared_mcmc_step_fn = partial(
@@ -34,7 +36,7 @@ def update_with_mcmc_take_last(
 
             keys = jax.random.split(rng_key, num_mcmc_steps)
             final_state, infos = jax.lax.scan(body_fn, state, keys)
-            return final_state, MCMCUpdateInfo(infos[0], infos[1])
+            return final_state, infos[1]  # MCMCUpdateInfo(infos[0], infos[1])
 
         return jax.vmap(mcmc_kernel)(rng_key, state)
 

--- a/blackjax/ns/from_mcmc.py
+++ b/blackjax/ns/from_mcmc.py
@@ -17,13 +17,9 @@ def update_with_mcmc_take_last(
 ):
     """An update strategy for NS that uses MCMC to update the particles."""
 
-    def update_function(
-        rng_key, state, logprior_fn, loglikelihood_fn, loglikelihood_0, step_parameters
-    ):
+    def update_function(rng_key, state, loglikelihood_0, step_parameters):
         shared_mcmc_step_fn = partial(
             constrained_mcmc_step_fn,
-            logprior_fn=logprior_fn,
-            loglikelihood_fn=loglikelihood_fn,
             loglikelihood_0=loglikelihood_0,
             **step_parameters,
         )

--- a/blackjax/ns/from_mcmc.py
+++ b/blackjax/ns/from_mcmc.py
@@ -32,11 +32,11 @@ def update_with_mcmc_take_last(
         def mcmc_kernel(rng_key, state):
             def body_fn(state, rng_key):
                 new_state, info = shared_mcmc_step_fn(rng_key, state)
-                return new_state, (new_state, info)
+                return new_state, info  # (new_state, info)
 
             keys = jax.random.split(rng_key, num_mcmc_steps)
             final_state, infos = jax.lax.scan(body_fn, state, keys)
-            return final_state, infos[1]  # MCMCUpdateInfo(infos[0], infos[1])
+            return final_state, infos  # MCMCUpdateInfo(infos[0], infos[1])
 
         return jax.vmap(mcmc_kernel)(rng_key, state)
 

--- a/blackjax/ns/from_mcmc.py
+++ b/blackjax/ns/from_mcmc.py
@@ -33,6 +33,6 @@ def update_with_mcmc_take_last(
             final_state, infos = jax.lax.scan(body_fn, state, keys)
             return final_state, MCMCUpdateInfo(infos[0], infos[1])
 
-        return jax.vmap(mcmc_kernel, in_axes=(0, 0))(rng_key, state)
+        return jax.vmap(mcmc_kernel)(rng_key, state)
 
     return update_function

--- a/blackjax/ns/from_mcmc.py
+++ b/blackjax/ns/from_mcmc.py
@@ -1,7 +1,10 @@
 from functools import partial
-from typing import NamedTuple
+from typing import Callable, NamedTuple
 
 import jax
+
+from blackjax.ns.adaptive import build_kernel as build_adaptive_kernel
+from blackjax.ns.base import delete_fn as default_delete_fn
 
 
 class MCMCUpdateInfo(NamedTuple):
@@ -36,3 +39,39 @@ def update_with_mcmc_take_last(
         return jax.vmap(mcmc_kernel)(rng_key, state)
 
     return update_function
+
+
+def build_kernel(
+    init_state_fn: Callable,
+    mcmc_init_fn: Callable,
+    mcmc_step_fn: Callable,
+    num_inner_steps: int,
+    update_inner_kernel_params_fn: Callable,
+    num_delete: int = 1,
+) -> Callable:
+    """Builds the Nested Slice Sampling kernel. wrapping any mcmc algorithm"""
+
+    def constrained_mcmc_step_fn(rng_key, state, loglikelihood_0, **params):
+        rng_key, prop_key = jax.random.split(rng_key, 2)
+        mcmc_state = mcmc_init_fn(rng_key, state.position, state.logprior)
+        new_mcmc_state, mcmc_info = mcmc_step_fn(prop_key, mcmc_state, **params)
+        new_state = init_state_fn(new_mcmc_state.position)
+        new_state = jax.lax.cond(
+            new_state.loglikelihood > loglikelihood_0,
+            lambda _: new_state,
+            lambda _: state,
+            operand=None,
+        )
+
+        return new_state, mcmc_info
+
+    inner_kernel = update_with_mcmc_take_last(constrained_mcmc_step_fn, num_inner_steps)
+
+    delete_fn = partial(default_delete_fn, num_delete=num_delete)
+
+    kernel = build_adaptive_kernel(
+        delete_fn,
+        inner_kernel,
+        update_inner_kernel_params_fn,
+    )
+    return kernel

--- a/blackjax/ns/nss.py
+++ b/blackjax/ns/nss.py
@@ -27,7 +27,7 @@ from blackjax.mcmc.ss import build_kernel as build_slice_kernel
 from blackjax.mcmc.ss import sample_direction_from_covariance
 from blackjax.ns.adaptive import build_kernel as build_adaptive_kernel
 from blackjax.ns.adaptive import init
-from blackjax.ns.base import NSInfo, NSState, PartitionedState
+from blackjax.ns.base import NSInfo, NSState, PartitionedInfo, PartitionedState
 from blackjax.ns.base import delete_fn as default_delete_fn
 from blackjax.ns.base import init_partitioned_state
 from blackjax.ns.utils import repeat_kernel
@@ -122,7 +122,10 @@ def build_kernel(
             logdensity=new_slice_state.logdensity,
             loglikelihood=new_slice_state.loglikelihood,
         )
-        return new_state, slice_info
+        new_info = PartitionedInfo(
+            transition_state=new_state, transition_info=slice_info
+        )
+        return new_state, new_info
 
     delete_fn = partial(default_delete_fn, num_delete=num_delete)
 

--- a/blackjax/ns/nss.py
+++ b/blackjax/ns/nss.py
@@ -17,7 +17,7 @@ Hit-and-Run Slice Sampling (HRSS) as the inner MCMC kernel.
 """
 
 from functools import partial
-from typing import Callable, Dict, NamedTuple, Optional
+from typing import Callable, Dict, Optional
 
 import jax
 import jax.numpy as jnp
@@ -29,63 +29,16 @@ from blackjax.ns.adaptive import build_kernel as build_adaptive_kernel
 from blackjax.ns.adaptive import init
 from blackjax.ns.base import NSInfo, NSState, PartitionedState
 from blackjax.ns.base import delete_fn as default_delete_fn
+from blackjax.ns.base import init_partitioned_state
 from blackjax.ns.utils import repeat_kernel
 from blackjax.smc.tuning.from_particles import particles_covariance_matrix
-from blackjax.types import Array, ArrayLikeTree, ArrayTree
+from blackjax.types import ArrayTree
 
 __all__ = [
     "init",
     "as_top_level_api",
     "build_kernel",
 ]
-
-
-class SliceStateWithLoglikelihood(NamedTuple):
-    """State used internally by nested slice sampling.
-
-    This extends the basic SliceState to track both the log-likelihood value
-    needed for the likelihood contour constraint.
-
-    Attributes
-    ----------
-    position
-        The current position in parameter space.
-    logdensity
-        The log-prior probability at the current position.
-    loglikelihood
-        The log-likelihood value at the current position.
-    """
-
-    position: ArrayLikeTree
-    logdensity: float
-    loglikelihood: Array
-
-
-class NSSInfo(NamedTuple):
-    """Additional information from the Nested Slice Sampling transition.
-
-    Attributes
-    ----------
-    position
-        The position(s) resulting from the slice sampling step.
-    logprior
-        The log-prior value(s) at the position(s).
-    loglikelihood
-        The log-likelihood value(s) at the position(s).
-    is_accepted
-        Whether the slice sampling proposal was accepted.
-    num_steps
-        The number of steps taken during the stepping-out phase.
-    num_shrink
-        The number of shrinking steps taken during the shrinking phase.
-    """
-
-    position: ArrayTree
-    logprior: ArrayTree
-    loglikelihood: ArrayTree
-    is_accepted: bool
-    num_steps: int
-    num_shrink: int
 
 
 def default_stepper_fn(x: ArrayTree, d: ArrayTree, t: float) -> tuple[ArrayTree, bool]:
@@ -119,19 +72,6 @@ def compute_covariance_from_particles(
     return {"cov": jnp.atleast_2d(particles_covariance_matrix(state.particles))}
 
 
-def init_slice_state(
-    position: ArrayTree, logprior_fn: Callable, loglikelihood_fn: Callable
-) -> SliceStateWithLoglikelihood:
-    """Simple default initialization function for NSS SliceState."""
-    logprior = logprior_fn(position)
-    loglikelihood = loglikelihood_fn(position)
-    return SliceStateWithLoglikelihood(
-        position=position,
-        logdensity=logprior,
-        loglikelihood=loglikelihood,
-    )
-
-
 def build_kernel(
     logprior_fn: Callable,
     loglikelihood_fn: Callable,
@@ -140,7 +80,7 @@ def build_kernel(
     stepper_fn: Callable = default_stepper_fn,
     adapt_direction_params_fn: Callable = compute_covariance_from_particles,
     generate_slice_direction_fn: Callable = sample_direction_from_covariance,
-    slice_init_fn: Callable = init_slice_state,
+    init_partitioned_state_fn: Callable = init_partitioned_state,
     max_steps: int = 10,
     max_shrinkage: int = 100,
 ) -> Callable:
@@ -156,14 +96,14 @@ def build_kernel(
         rng_key, prop_key = jax.random.split(rng_key, 2)
         d = generate_slice_direction_fn(prop_key, state.position, **params)
 
-        def slice_fn(t) -> tuple[SliceStateWithLoglikelihood, bool]:
+        def slice_fn(t) -> tuple[PartitionedState, bool]:
             x, step_accepted = stepper_fn(state.position, d, t)
-            new_state = slice_init_fn(x, logprior_fn, loglikelihood_fn)
+            new_state = init_partitioned_state_fn(x, logprior_fn, loglikelihood_fn)
             in_contour = new_state.loglikelihood > loglikelihood_0
             is_accepted = in_contour & step_accepted
             return new_state, is_accepted
 
-        slice_state = slice_init_fn(
+        slice_state = init_partitioned_state_fn(
             position=state.position,
             logprior_fn=logprior_fn,
             loglikelihood_fn=loglikelihood_fn,
@@ -176,20 +116,13 @@ def build_kernel(
         )
         new_slice_state, slice_info = slice_kernel(rng_key, slice_state)
 
+        # Instantiate new PartitionedState directly to avoid double count
         new_state = PartitionedState(
             position=new_slice_state.position,
-            logprior=new_slice_state.logdensity,
+            logdensity=new_slice_state.logdensity,
             loglikelihood=new_slice_state.loglikelihood,
         )
-        info = NSSInfo(
-            position=new_slice_state.position,
-            logprior=new_slice_state.logdensity,
-            loglikelihood=new_slice_state.loglikelihood,
-            is_accepted=slice_info.is_accepted,
-            num_steps=slice_info.num_steps,
-            num_shrink=slice_info.num_shrink,
-        )
-        return new_state, info
+        return new_state, slice_info
 
     delete_fn = partial(default_delete_fn, num_delete=num_delete)
 
@@ -212,7 +145,7 @@ def as_top_level_api(
     stepper_fn: Callable = default_stepper_fn,
     adapt_direction_params_fn: Callable = compute_covariance_from_particles,
     generate_slice_direction_fn: Callable = sample_direction_from_covariance,
-    slice_init_fn: Callable = init_slice_state,
+    init_partitioned_state_fn: Callable = init_partitioned_state,
     max_steps: int = 10,
     max_shrinkage: int = 100,
 ) -> SamplingAlgorithm:
@@ -269,7 +202,7 @@ def as_top_level_api(
         stepper_fn=stepper_fn,
         adapt_direction_params_fn=adapt_direction_params_fn,
         generate_slice_direction_fn=generate_slice_direction_fn,
-        slice_init_fn=slice_init_fn,
+        init_partitioned_state_fn=init_partitioned_state_fn,
         max_steps=max_steps,
         max_shrinkage=max_shrinkage,
     )

--- a/blackjax/ns/nss.py
+++ b/blackjax/ns/nss.py
@@ -27,10 +27,10 @@ from blackjax.mcmc.ss import build_kernel as build_slice_kernel
 from blackjax.mcmc.ss import sample_direction_from_covariance
 from blackjax.ns.adaptive import build_kernel as build_adaptive_kernel
 from blackjax.ns.adaptive import init
-from blackjax.ns.base import NSInfo, NSState, PartitionedInfo, PartitionedState
+from blackjax.ns.base import NSInfo, NSState, StateWithLogLikelihood
 from blackjax.ns.base import delete_fn as default_delete_fn
-from blackjax.ns.base import init_partitioned_state
-from blackjax.ns.utils import repeat_kernel
+from blackjax.ns.base import init_state_with_likelihood
+from blackjax.ns.from_mcmc import update_with_mcmc_take_last
 from blackjax.smc.tuning.from_particles import particles_covariance_matrix
 from blackjax.types import ArrayTree
 
@@ -80,7 +80,7 @@ def build_kernel(
     stepper_fn: Callable = default_stepper_fn,
     adapt_direction_params_fn: Callable = compute_covariance_from_particles,
     generate_slice_direction_fn: Callable = sample_direction_from_covariance,
-    init_partitioned_state_fn: Callable = init_partitioned_state,
+    init_partitioned_state_fn: Callable = init_state_with_likelihood,
     max_steps: int = 10,
     max_shrinkage: int = 100,
 ) -> Callable:
@@ -89,43 +89,30 @@ def build_kernel(
     see `as_top_level_api` for parameter descriptions.
     """
 
-    @repeat_kernel(num_inner_steps)
-    def inner_kernel(
-        rng_key, state, logprior_fn, loglikelihood_fn, loglikelihood_0, params
+    def constrained_mcmc_slice_fn(
+        rng_key, state, logprior_fn, loglikelihood_fn, loglikelihood_0, **params
     ):
         rng_key, prop_key = jax.random.split(rng_key, 2)
         d = generate_slice_direction_fn(prop_key, state.position, **params)
 
-        def slice_fn(t) -> tuple[PartitionedState, bool]:
+        def slice_fn(t) -> tuple[StateWithLogLikelihood, bool]:
             x, step_accepted = stepper_fn(state.position, d, t)
             new_state = init_partitioned_state_fn(x, logprior_fn, loglikelihood_fn)
             in_contour = new_state.loglikelihood > loglikelihood_0
             is_accepted = in_contour & step_accepted
             return new_state, is_accepted
 
-        slice_state = init_partitioned_state_fn(
-            position=state.position,
-            logprior_fn=logprior_fn,
-            loglikelihood_fn=loglikelihood_fn,
-        )
-
         slice_kernel = build_slice_kernel(
             slice_fn,
             max_steps=max_steps,
             max_shrinkage=max_shrinkage,
         )
-        new_slice_state, slice_info = slice_kernel(rng_key, slice_state)
+        new_slice_state, slice_info = slice_kernel(rng_key, state)
+        return new_slice_state, slice_info
 
-        # Instantiate new PartitionedState directly to avoid double count
-        new_state = PartitionedState(
-            position=new_slice_state.position,
-            logdensity=new_slice_state.logdensity,
-            loglikelihood=new_slice_state.loglikelihood,
-        )
-        new_info = PartitionedInfo(
-            transition_state=new_state, transition_info=slice_info
-        )
-        return new_state, new_info
+    inner_kernel = update_with_mcmc_take_last(
+        constrained_mcmc_slice_fn, num_inner_steps
+    )
 
     delete_fn = partial(default_delete_fn, num_delete=num_delete)
 
@@ -134,7 +121,7 @@ def build_kernel(
         logprior_fn,
         loglikelihood_fn,
         delete_fn,
-        jax.vmap(inner_kernel, in_axes=(0, 0, None, None, None, None)),
+        inner_kernel,
         update_inner_kernel_params_fn,
     )
     return kernel
@@ -148,7 +135,7 @@ def as_top_level_api(
     stepper_fn: Callable = default_stepper_fn,
     adapt_direction_params_fn: Callable = compute_covariance_from_particles,
     generate_slice_direction_fn: Callable = sample_direction_from_covariance,
-    init_partitioned_state_fn: Callable = init_partitioned_state,
+    init_partitioned_state_fn: Callable = init_state_with_likelihood,
     max_steps: int = 10,
     max_shrinkage: int = 100,
 ) -> SamplingAlgorithm:

--- a/blackjax/ns/nss.py
+++ b/blackjax/ns/nss.py
@@ -120,13 +120,13 @@ def compute_covariance_from_particles(
 
 
 def init_slice_state(
-    x: ArrayTree, logprior_fn: Callable, loglikelihood_fn: Callable
+    position: ArrayTree, logprior_fn: Callable, loglikelihood_fn: Callable
 ) -> SliceStateWithLoglikelihood:
     """Simple default initialization function for NSS SliceState."""
-    logprior = logprior_fn(x)
-    loglikelihood = loglikelihood_fn(x)
+    logprior = logprior_fn(position)
+    loglikelihood = loglikelihood_fn(position)
     return SliceStateWithLoglikelihood(
-        position=x,
+        position=position,
         logdensity=logprior,
         loglikelihood=loglikelihood,
     )

--- a/blackjax/ns/nss.py
+++ b/blackjax/ns/nss.py
@@ -29,7 +29,7 @@ from blackjax.ns.adaptive import build_kernel as build_adaptive_kernel
 from blackjax.ns.adaptive import init
 from blackjax.ns.base import NSInfo, NSState, StateWithLogLikelihood
 from blackjax.ns.base import delete_fn as default_delete_fn
-from blackjax.ns.base import init_state_with_likelihood
+from blackjax.ns.base import init_state_strategy
 from blackjax.ns.from_mcmc import update_with_mcmc_take_last
 from blackjax.smc.tuning.from_particles import particles_covariance_matrix
 from blackjax.types import ArrayTree
@@ -73,14 +73,12 @@ def compute_covariance_from_particles(
 
 
 def build_kernel(
-    logprior_fn: Callable,
-    loglikelihood_fn: Callable,
+    init_state_fn: Callable,
     num_inner_steps: int,
     num_delete: int = 1,
     stepper_fn: Callable = default_stepper_fn,
     adapt_direction_params_fn: Callable = compute_covariance_from_particles,
     generate_slice_direction_fn: Callable = sample_direction_from_covariance,
-    init_inner_state_fn: Callable = init_state_with_likelihood,
     max_steps: int = 10,
     max_shrinkage: int = 100,
 ) -> Callable:
@@ -95,7 +93,7 @@ def build_kernel(
 
         def slice_fn(t) -> tuple[StateWithLogLikelihood, bool]:
             x, step_accepted = stepper_fn(state.position, d, t)
-            new_state = init_inner_state_fn(x, logprior_fn, loglikelihood_fn)
+            new_state = init_state_fn(x)
             in_contour = new_state.loglikelihood > loglikelihood_0
             is_accepted = in_contour & step_accepted
             return new_state, is_accepted
@@ -131,7 +129,7 @@ def as_top_level_api(
     stepper_fn: Callable = default_stepper_fn,
     adapt_direction_params_fn: Callable = compute_covariance_from_particles,
     generate_slice_direction_fn: Callable = sample_direction_from_covariance,
-    init_inner_state_fn: Callable = init_state_with_likelihood,
+    init_state_strategy_fn: Callable = init_state_strategy,
     max_steps: int = 10,
     max_shrinkage: int = 100,
 ) -> SamplingAlgorithm:
@@ -179,16 +177,19 @@ def as_top_level_api(
         the configured Nested Slice Sampler. The state managed by this
         algorithm is `NSState`.
     """
+    init_state_fn = partial(
+        init_state_strategy_fn,
+        logprior_fn=logprior_fn,
+        loglikelihood_fn=loglikelihood_fn,
+    )
 
     kernel = build_kernel(
-        logprior_fn,
-        loglikelihood_fn,
+        init_state_fn,
         num_inner_steps,
         num_delete,
         stepper_fn=stepper_fn,
         adapt_direction_params_fn=adapt_direction_params_fn,
         generate_slice_direction_fn=generate_slice_direction_fn,
-        init_inner_state_fn=init_inner_state_fn,
         max_steps=max_steps,
         max_shrinkage=max_shrinkage,
     )
@@ -197,8 +198,7 @@ def as_top_level_api(
         # Vectorize the functions for parallel evaluation over particles
         return init(
             position,
-            logprior_fn=jax.vmap(logprior_fn),
-            loglikelihood_fn=jax.vmap(loglikelihood_fn),
+            init_state_fn=jax.vmap(init_state_fn),
             update_inner_kernel_params_fn=adapt_direction_params_fn,
         )
 

--- a/blackjax/ns/nss.py
+++ b/blackjax/ns/nss.py
@@ -89,9 +89,7 @@ def build_kernel(
     see `as_top_level_api` for parameter descriptions.
     """
 
-    def constrained_mcmc_slice_fn(
-        rng_key, state, logprior_fn, loglikelihood_fn, loglikelihood_0, **params
-    ):
+    def constrained_mcmc_slice_fn(rng_key, state, loglikelihood_0, **params):
         rng_key, prop_key = jax.random.split(rng_key, 2)
         d = generate_slice_direction_fn(prop_key, state.position, **params)
 
@@ -118,8 +116,6 @@ def build_kernel(
 
     update_inner_kernel_params_fn = adapt_direction_params_fn
     kernel = build_adaptive_kernel(
-        logprior_fn,
-        loglikelihood_fn,
         delete_fn,
         inner_kernel,
         update_inner_kernel_params_fn,

--- a/blackjax/ns/nss.py
+++ b/blackjax/ns/nss.py
@@ -33,6 +33,7 @@ from jax.flatten_util import ravel_pytree
 from blackjax import SamplingAlgorithm
 from blackjax.mcmc.ss import SliceState
 from blackjax.mcmc.ss import build_kernel as build_slice_kernel
+from blackjax.mcmc.ss import init as init_slice
 from blackjax.mcmc.ss import default_stepper_fn
 from blackjax.mcmc.ss import (
     sample_direction_from_covariance as ss_sample_direction_from_covariance,
@@ -148,6 +149,7 @@ def build_kernel(
     stepper_fn: Callable = default_stepper_fn,
     adapt_direction_params_fn: Callable = compute_covariance_from_particles,
     generate_slice_direction_fn: Callable = sample_direction_from_covariance,
+    slice_init_fn: Callable = init_slice,
     max_steps: int = 10,
     max_shrinkage: int = 100,
 ) -> Callable:
@@ -196,7 +198,7 @@ def build_kernel(
         the `NSInfo` for the step.
     """
 
-    slice_kernel = build_slice_kernel(stepper_fn, max_steps, max_shrinkage)
+    slice_kernel = build_slice_kernel(stepper_fn, init_fn=slice_init_fn, max_steps=max_steps, max_shrinkage=max_shrinkage)
 
     @repeat_kernel(num_inner_steps)
     def inner_kernel(
@@ -206,14 +208,14 @@ def build_kernel(
         slice_state = SliceState(
             position=state.position,
             logdensity=state.logprior,
-            constraint=jnp.array([state.loglikelihood]),
+            constraint=state.loglikelihood
         )
         rng_key, prop_key = jax.random.split(rng_key, 2)
         d = generate_slice_direction_fn(prop_key, params)
         logdensity_fn = logprior_fn
-        constraint_fn = lambda x: jnp.array([loglikelihood_fn(x)])
-        constraint = jnp.array([loglikelihood_0])
-        strict = jnp.array([True])
+        constraint_fn = loglikelihood_fn
+        constraint = loglikelihood_0
+        strict = True
         new_slice_state, slice_info = slice_kernel(
             rng_key, slice_state, logdensity_fn, d, constraint_fn, constraint, strict
         )
@@ -222,7 +224,7 @@ def build_kernel(
         return new_state_and_info(
             position=new_slice_state.position,
             logprior=new_slice_state.logdensity,
-            loglikelihood=new_slice_state.constraint[0],
+            loglikelihood=new_slice_state.constraint,
             info=slice_info,
         )
 
@@ -250,6 +252,7 @@ def as_top_level_api(
     stepper_fn: Callable = default_stepper_fn,
     adapt_direction_params_fn: Callable = compute_covariance_from_particles,
     generate_slice_direction_fn: Callable = sample_direction_from_covariance,
+    slice_init_fn: Callable = init_slice,
     max_steps: int = 10,
     max_shrinkage: int = 100,
 ) -> SamplingAlgorithm:
@@ -306,6 +309,7 @@ def as_top_level_api(
         stepper_fn=stepper_fn,
         adapt_direction_params_fn=adapt_direction_params_fn,
         generate_slice_direction_fn=generate_slice_direction_fn,
+        slice_init_fn=slice_init_fn,
         max_steps=max_steps,
         max_shrinkage=max_shrinkage,
     )

--- a/blackjax/ns/nss.py
+++ b/blackjax/ns/nss.py
@@ -80,7 +80,7 @@ def build_kernel(
     stepper_fn: Callable = default_stepper_fn,
     adapt_direction_params_fn: Callable = compute_covariance_from_particles,
     generate_slice_direction_fn: Callable = sample_direction_from_covariance,
-    init_partitioned_state_fn: Callable = init_state_with_likelihood,
+    init_inner_state_fn: Callable = init_state_with_likelihood,
     max_steps: int = 10,
     max_shrinkage: int = 100,
 ) -> Callable:
@@ -97,7 +97,7 @@ def build_kernel(
 
         def slice_fn(t) -> tuple[StateWithLogLikelihood, bool]:
             x, step_accepted = stepper_fn(state.position, d, t)
-            new_state = init_partitioned_state_fn(x, logprior_fn, loglikelihood_fn)
+            new_state = init_inner_state_fn(x, logprior_fn, loglikelihood_fn)
             in_contour = new_state.loglikelihood > loglikelihood_0
             is_accepted = in_contour & step_accepted
             return new_state, is_accepted
@@ -135,7 +135,7 @@ def as_top_level_api(
     stepper_fn: Callable = default_stepper_fn,
     adapt_direction_params_fn: Callable = compute_covariance_from_particles,
     generate_slice_direction_fn: Callable = sample_direction_from_covariance,
-    init_partitioned_state_fn: Callable = init_state_with_likelihood,
+    init_inner_state_fn: Callable = init_state_with_likelihood,
     max_steps: int = 10,
     max_shrinkage: int = 100,
 ) -> SamplingAlgorithm:
@@ -192,7 +192,7 @@ def as_top_level_api(
         stepper_fn=stepper_fn,
         adapt_direction_params_fn=adapt_direction_params_fn,
         generate_slice_direction_fn=generate_slice_direction_fn,
-        init_partitioned_state_fn=init_partitioned_state_fn,
+        init_inner_state_fn=init_inner_state_fn,
         max_steps=max_steps,
         max_shrinkage=max_shrinkage,
     )

--- a/blackjax/ns/utils.py
+++ b/blackjax/ns/utils.py
@@ -242,8 +242,7 @@ def finalise(live: NSState, dead: list[NSInfo]) -> NSInfo:
             live.loglikelihood,
             live.loglikelihood_birth,
             live.logprior,
-            dead[-1].inner_kernel_states,
-            dead[-1].inner_kernel_info,
+            dead[-1].update_info,
         )
     ]
     combined_dead_info = jax.tree.map(

--- a/blackjax/ns/utils.py
+++ b/blackjax/ns/utils.py
@@ -150,8 +150,9 @@ def logX(rng_key: PRNGKey, dead_info: NSInfo, shape: int = 100) -> tuple[Array, 
     min_val = jnp.finfo(dead_info.loglikelihood.dtype).tiny
     r = jnp.log(
         jax.random.uniform(
-            subkey, shape=(dead_info.loglikelihood.shape[0], shape),
-            dtype=dead_info.loglikelihood.dtype
+            subkey,
+            shape=(dead_info.loglikelihood.shape[0], shape),
+            dtype=dead_info.loglikelihood.dtype,
         ).clip(min_val, 1 - min_val)
     )
 
@@ -159,8 +160,12 @@ def logX(rng_key: PRNGKey, dead_info: NSInfo, shape: int = 100) -> tuple[Array, 
     t = r / num_live[:, jnp.newaxis]
     logX = jnp.cumsum(t, axis=0)
 
-    logXp = jnp.concatenate([jnp.zeros((1, logX.shape[1]), dtype=logX.dtype), logX[:-1]], axis=0)
-    logXm = jnp.concatenate([logX[1:], jnp.full((1, logX.shape[1]), -jnp.inf, dtype=logX.dtype)], axis=0)
+    logXp = jnp.concatenate(
+        [jnp.zeros((1, logX.shape[1]), dtype=logX.dtype), logX[:-1]], axis=0
+    )
+    logXm = jnp.concatenate(
+        [logX[1:], jnp.full((1, logX.shape[1]), -jnp.inf, dtype=logX.dtype)], axis=0
+    )
     log_diff = logXm - logXp
     logdX = log1mexp(log_diff) + logXp - jnp.log(2)
     return logX, logdX
@@ -237,6 +242,7 @@ def finalise(live: NSState, dead: list[NSInfo]) -> NSInfo:
             live.loglikelihood,
             live.loglikelihood_birth,
             live.logprior,
+            dead[-1].inner_kernel_states,
             dead[-1].inner_kernel_info,
         )
     ]

--- a/tests/mcmc/test_slice_sampling.py
+++ b/tests/mcmc/test_slice_sampling.py
@@ -46,12 +46,10 @@ class SliceSamplingTest(chex.TestCase):
         key = jax.random.key(456)
         position = jnp.zeros(ndim)
 
-        # Build kernel with normalized random direction
-        def direction_fn(rng_key, pos):
-            d = jax.random.normal(rng_key, (ndim,))
-            return d / jnp.linalg.norm(d)
+        # Build kernel with identity covariance matrix
+        cov = jnp.eye(ndim)
 
-        kernel = ss.build_hrss_kernel(direction_fn)
+        kernel = ss.build_hrss_kernel(cov)
         state = ss.init(position, logdensity_fn)
 
         # Take one step
@@ -111,10 +109,13 @@ class SliceSamplingTest(chex.TestCase):
 
         chex.assert_shape(direction, (3,))
 
-        # Direction should be normalized in Mahalanobis sense
+        # Direction should be normalized in Mahalanobis sense with scaling factor
+        # The scaling factor is 2 * sqrt(dim + 2)
+        dim = 3
+        expected_norm = 2 * jnp.sqrt(dim + 2)
         invcov = jnp.linalg.inv(cov)
         mahal_norm = jnp.sqrt(jnp.einsum("i,ij,j", direction, invcov, direction))
-        chex.assert_trees_all_close(mahal_norm, 1.0, atol=1e-6)
+        chex.assert_trees_all_close(mahal_norm, expected_norm, atol=1e-6)
 
     def test_hrss_top_level_api(self):
         """Test hit-and-run slice sampling top-level API"""


### PR DESCRIPTION
This PR adds an explicit init function for NSS, and aligns API of both SS and NSS in having a flexible to define init function, this should let one interfere with the calculation of logl and logpi in useful and profitable ways.

Tests currently broken, I suspect as I reverted the change to include position in kwargs. I’d prefer not to have this as for writing new tuning functions it isn’t clear why you _have_to include position, and it leads to implications that this is somehow a privileged position.
