### PR TITLE
Add derived parameters support to Nested Sampling

### DIFF
--- a/blackjax/ns/adaptive.py
+++ b/blackjax/ns/adaptive.py
@@ -38,6 +38,8 @@ def init(
     particles: ArrayLikeTree,
     init_state_fn: Callable,
     loglikelihood_birth: Array = -jnp.nan,
+    logX: Optional[Array] = 0.0,
+    logZ: Optional[Array] = -jnp.inf,
     update_inner_kernel_params_fn: Optional[Callable] = None,
 ) -> NSState:
     """Initializes the Nested Sampler state.
@@ -65,7 +67,7 @@ def init(
     NSState
         The initial state of the Nested Sampler.
     """
-    state = base_init(particles, init_state_fn, loglikelihood_birth)
+    state = base_init(particles, init_state_fn, loglikelihood_birth, logX, logZ)
     if update_inner_kernel_params_fn is not None:
         inner_kernel_params = update_inner_kernel_params_fn(state, None, {})
         state = state._replace(inner_kernel_params=inner_kernel_params)

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -57,6 +57,8 @@ class NSState(NamedTuple):
         This is used for reconstructing the nested sampling path.
     logprior
         An array of log-prior values, one for each live particle.
+    derived
+        Optional PyTree of derived parameters for each particle, conditional on positions.
     pid
         Particle ID. An array of integers tracking the identity or lineage of
         particles, primarily for diagnostic purposes.
@@ -74,6 +76,7 @@ class NSState(NamedTuple):
     loglikelihood: Array  # The log-likelihood of the particles
     loglikelihood_birth: Array  # The log-likelihood threshold at particle birth
     logprior: Array  # The log-prior density of the particles
+    derived: ArrayLikeTree  # Derived parameters for particles
     pid: Array  # particle IDs
     logX: Array  # The current log-volume estimate
     logZ: Array  # The accumulated evidence estimate
@@ -95,6 +98,8 @@ class NSInfo(NamedTuple):
         The birth log-likelihood thresholds of the dead particles.
     logprior
         The log-prior values of the dead particles.
+    derived
+        Optional PyTree of derived parameters for the dead particles.
     update_info
         A NamedTuple (or any PyTree) containing information from the update step
         (inner kernel) used to generate new live particles. The content
@@ -105,6 +110,7 @@ class NSInfo(NamedTuple):
     loglikelihood: Array  # The log-likelihood of the particles
     loglikelihood_birth: Array  # The log-likelihood threshold at particle birth
     logprior: Array  # The log-prior density of the particles
+    derived: ArrayLikeTree  # Derived parameters for dead particles
     update_info: NamedTuple
 
 
@@ -122,21 +128,28 @@ class StateWithLogLikelihood(NamedTuple):
     position
         A PyTree of arrays representing the current positions of the particles.
         Each leaf array has a leading dimension corresponding to the number of particles.
-    logprior
+    logdensity
         An array of log-prior density values evaluated at the particle positions.
         Shape: (n_particles,)
     loglikelihood
         An array of log-likelihood values evaluated at the particle positions.
         Shape: (n_particles,)
+    derived
+        Optional PyTree of derived parameters that are conditional on the position.
+        These are computed from the position but not sampled directly.
     """
 
     position: ArrayLikeTree  # Current positions of particles in the inner kernel
     logdensity: Array  # Log-prior values for particles in the inner kernel
     loglikelihood: Array  # Log-likelihood values for particles in the inner kernel
+    derived: ArrayLikeTree  # Derived parameters conditional on position
 
 
 def init_state_strategy(
-    position: ArrayLikeTree, logprior_fn: Callable, loglikelihood_fn: Callable
+    position: ArrayLikeTree,
+    logprior_fn: Callable,
+    loglikelihood_fn: Callable,
+    derived_fn: Callable,
 ) -> StateWithLogLikelihood:
     """The default initialisation strategy for each state.
 
@@ -145,19 +158,26 @@ def init_state_strategy(
     position
         A PyTree of arrays representing the initial positions of the particles.
         Each leaf array has a leading dimension corresponding to the number of particles.
-    logprior
+    logprior_fn
         A function that computes the log-prior density for a single particle.
-    loglikelihood
+    loglikelihood_fn
         A function that computes the log-likelihood for a single particle.
+    derived_fn
+        Function that computes derived parameters from the position.
+        These are parameters conditional on the sampled position.
 
     Returns
     -------
-    PartitionedState
-        The initialized state containing positions, log-prior, and log-likelihood.
+    StateWithLogLikelihood
+        The initialized state containing positions, log-prior, log-likelihood,
+        and derived parameters.
     """
     logprior_values = logprior_fn(position)
     loglikelihood_values = loglikelihood_fn(position)
-    return StateWithLogLikelihood(position, logprior_values, loglikelihood_values)
+    derived_values = derived_fn(position)
+    return StateWithLogLikelihood(
+        position, logprior_values, loglikelihood_values, derived_values
+    )
 
 
 def init(
@@ -196,6 +216,7 @@ def init(
     loglikelihood = state.loglikelihood
     loglikelihood_birth = loglikelihood_birth * jnp.ones_like(loglikelihood)
     logprior = state.logdensity
+    derived = state.derived
     pid = jnp.arange(len(loglikelihood), dtype=jnp.int32)
     dtype = loglikelihood.dtype
     logX = jnp.array(logX, dtype=dtype)
@@ -207,6 +228,7 @@ def init(
         loglikelihood,
         loglikelihood_birth,
         logprior,
+        derived,
         pid,
         logX,
         logZ,
@@ -271,6 +293,7 @@ def build_kernel(
         dead_loglikelihood = state.loglikelihood[dead_idx]
         dead_loglikelihood_birth = state.loglikelihood_birth[dead_idx]
         dead_logprior = state.logprior[dead_idx]
+        dead_derived = jax.tree.map(lambda x: x[dead_idx], state.derived)
 
         # Resample the live particles
         loglikelihood_0 = dead_loglikelihood.max()
@@ -279,7 +302,8 @@ def build_kernel(
         particles = jax.tree.map(lambda x: x[start_idx], state.particles)
         logprior = state.logprior[start_idx]
         loglikelihood = state.loglikelihood[start_idx]
-        inner_state = StateWithLogLikelihood(particles, logprior, loglikelihood)
+        derived = jax.tree.map(lambda x: x[start_idx], state.derived)
+        inner_state = StateWithLogLikelihood(particles, logprior, loglikelihood, derived)
         new_inner_state, inner_update_info = inner_kernel(
             sample_keys,
             inner_state,
@@ -300,6 +324,11 @@ def build_kernel(
             loglikelihood_0
         )
         logprior = state.logprior.at[target_update_idx].set(new_inner_state.logdensity)
+        derived = jax.tree_util.tree_map(
+            lambda p, n: p.at[target_update_idx].set(n),
+            state.derived,
+            new_inner_state.derived,
+        )
         pid = state.pid.at[target_update_idx].set(state.pid[start_idx])
 
         # Update the run-time information
@@ -313,6 +342,7 @@ def build_kernel(
             loglikelihood,
             loglikelihood_birth,
             logprior,
+            derived,
             pid,
             logX,
             logZ,
@@ -324,6 +354,7 @@ def build_kernel(
             dead_loglikelihood,
             dead_loglikelihood_birth,
             dead_logprior,
+            dead_derived,
             inner_update_info,
         )
         return state, info

--- a/blackjax/ns/nss.py
+++ b/blackjax/ns/nss.py
@@ -121,11 +121,17 @@ def build_kernel(
     return kernel
 
 
+def default_derived_fn(x):
+    """Default derived function that returns empty dict."""
+    return {}
+
+
 def as_top_level_api(
     logprior_fn: Callable,
     loglikelihood_fn: Callable,
     num_inner_steps: int,
     num_delete: int = 1,
+    derived_fn: Callable = default_derived_fn,
     stepper_fn: Callable = default_stepper_fn,
     adapt_direction_params_fn: Callable = compute_covariance_from_particles,
     generate_slice_direction_fn: Callable = sample_direction_from_covariance,
@@ -152,6 +158,9 @@ def as_top_level_api(
     num_delete
         The number of particles to delete and replace at each NS step.
         Defaults to 1.
+    derived_fn
+        A function that computes derived parameters from a particle position.
+        Defaults to a function returning an empty dict.
     stepper_fn
         The stepper function `(x, direction, t) -> (x_new, is_accepted)` for the HRSS kernel.
         Defaults to `default_stepper_fn`.
@@ -181,6 +190,7 @@ def as_top_level_api(
         init_state_strategy_fn,
         logprior_fn=logprior_fn,
         loglikelihood_fn=loglikelihood_fn,
+        derived_fn=derived_fn,
     )
 
     kernel = build_kernel(

--- a/blackjax/ns/utils.py
+++ b/blackjax/ns/utils.py
@@ -242,6 +242,7 @@ def finalise(live: NSState, dead: list[NSInfo]) -> NSInfo:
             live.loglikelihood,
             live.loglikelihood_birth,
             live.logprior,
+            live.derived,
             dead[-1].update_info,
         )
     ]

--- a/docs/examples/nested_sampling.py
+++ b/docs/examples/nested_sampling.py
@@ -25,6 +25,16 @@ def loglikelihood_fn(x):
     return jax.scipy.stats.multivariate_normal.logpdf(x, mean=like_mean, cov=like_cov)
 
 
+def derived_fn(x):
+    """Compute derived parameters from position.
+
+    For this example, we compute simple derived quantities:
+    - norm: the L2 norm of the position vector
+    - sum: the sum of the position components
+    """
+    return {"norm": jnp.linalg.norm(x), "sum": jnp.sum(x)}
+
+
 def compute_logZ(mu_L, Sigma_L, logLmax=0, mu_pi=None, Sigma_pi=None):
     Sigma_P = inv(inv(Sigma_pi) + inv(Sigma_L))
     mu_P = jnp.dot(Sigma_P, (solve(Sigma_pi, mu_pi) + solve(Sigma_L, mu_L)))
@@ -67,6 +77,7 @@ num_inner_steps = d * 5
 algo = blackjax.nss(
     logprior_fn=logprior_fn,
     loglikelihood_fn=loglikelihood_fn,
+    derived_fn=derived_fn,
     num_delete=num_delete,
     num_inner_steps=num_inner_steps,
 )


### PR DESCRIPTION
## Summary
This PR implements support for derived parameters in the Nested Sampling framework. Derived parameters are quantities computed from the sampled positions but not directly sampled (e.g., power spectra, derived physical quantities).

## Changes Made
- Added `derived` field to `NSState`, `NSInfo`, and `StateWithLogLikelihood`
- Updated `init_state_strategy` to accept `derived_fn` parameter for computing derived quantities
- Modified base kernel to properly index and update derived parameters alongside positions
- Updated `nss.as_top_level_api` with **optional** `derived_fn` parameter (defaults to function returning empty dict)
- Updated `utils.finalise` to include derived parameters in final combined info
- Added example derived function to `docs/examples/nested_sampling.py`

## Design Decisions
- Derived parameters are **optional** - `derived_fn` defaults to returning an empty dict if not provided
- Derived parameters follow the same indexing and update patterns as `particles`, `loglikelihood`, and `logprior`
- Derived quantities are recalculated by the inner kernel via `init_state_fn` when positions change
- Stored in both `NSState` (for live particles) and `NSInfo` (for dead particles)

## Testing
- Imports work correctly
- Example in `docs/examples/nested_sampling.py` runs successfully with derived_fn
- Tested that NSS works without providing derived_fn (uses default empty dict)

## Notes
This is the first commit implementing the derived parameter structure as discussed in the meeting. A follow-up PR will address making the update strategy configurable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)