### PR TITLE
Refactor NS to separate live state from evidence integration

### DIFF
--- a/blackjax/ns/adaptive.py
+++ b/blackjax/ns/adaptive.py
@@ -37,7 +37,7 @@ __all__ = ["init", "build_kernel"]
 def init(
     particles: ArrayLikeTree,
     init_state_fn: Callable,
-    loglikelihood_birth: Array = -jnp.nan,
+    loglikelihood_birth: Array = jnp.nan,
     update_inner_kernel_params_fn: Optional[Callable] = None,
 ) -> NSState:
     """Initializes the Nested Sampler state.

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -40,41 +40,55 @@ from blackjax.types import Array, ArrayLikeTree, ArrayTree, PRNGKey
 __all__ = ["init", "build_kernel", "NSState", "NSInfo", "delete_fn"]
 
 
+class StateWithLogLikelihood(NamedTuple):
+    """State container that partitions out the loglikelihood and logprior.
+
+    This intermediate construction wraps around the usual State of an MCMC chain
+    so that the loglikelihood and logprior can be efficiently recorded, a
+    necessary step for the Partition function reconstruction that Nested
+    Sampling builds.
+
+    Attributes
+    ----------
+    position
+        A PyTree representing the position of the particle in parameter space.
+    logdensity
+        The log-prior density value of the particle.
+    loglikelihood
+        The log-likelihood value of the particle.
+    """
+
+    position: ArrayLikeTree
+    logdensity: Array
+    loglikelihood: Array
+
+
 class NSState(NamedTuple):
     """State of the Nested Sampler.
 
     Attributes
     ----------
     particles
-        A PyTree of arrays, where each leaf array has a leading dimension
-        equal to the number of live particles. Stores the current positions of
-        the live particles.
-    loglikelihood
-        An array of log-likelihood values, one for each live particle.
+        StateWithLogLikelihood containing the current live particles.
     loglikelihood_birth
         An array storing the log-likelihood threshold that each current live
         particle was required to exceed when it was "born" (i.e., sampled).
-        This is used for reconstructing the nested sampling path.
-    logprior
-        An array of log-prior values, one for each live particle.
     logX
         The log of the current prior volume estimate.
     logZ
-        The accumulated log evidence estimate from the "dead" points .
+        The accumulated log evidence estimate from the "dead" points.
     logZ_live
         The current estimate of the log evidence contribution from the live points.
     inner_kernel_params
         A dictionary of parameters for the inner kernel.
     """
 
-    particles: ArrayLikeTree
-    loglikelihood: Array  # The log-likelihood of the particles
-    loglikelihood_birth: Array  # The log-likelihood threshold at particle birth
-    logprior: Array  # The log-prior density of the particles
-    logX: Array  # The current log-volume estimate
-    logZ: Array  # The accumulated evidence estimate
-    logZ_live: Array  # The current evidence estimate
-    inner_kernel_params: Dict  # Parameters for the inner kernel
+    particles: StateWithLogLikelihood
+    loglikelihood_birth: Array
+    logX: Array
+    logZ: Array
+    logZ_live: Array
+    inner_kernel_params: Dict
 
 
 class NSInfo(NamedTuple):
@@ -83,52 +97,20 @@ class NSInfo(NamedTuple):
     Attributes
     ----------
     particles
-        The PyTree of particles that were marked as "dead" (replaced) in the
-        current step.
+        The StateWithLogLikelihood of particles that were marked as "dead" (replaced).
     loglikelihood
-        The log-likelihood values of the dead particles.
+        The log-likelihood values of the dead particles (extracted for evidence calculation).
     loglikelihood_birth
         The birth log-likelihood thresholds of the dead particles.
-    logprior
-        The log-prior values of the dead particles.
     update_info
         A NamedTuple (or any PyTree) containing information from the update step
-        (inner kernel) used to generate new live particles. The content
-        depends on the specific inner kernel used.
+        (inner kernel) used to generate new live particles.
     """
 
-    particles: ArrayTree
-    loglikelihood: Array  # The log-likelihood of the particles
-    loglikelihood_birth: Array  # The log-likelihood threshold at particle birth
-    logprior: Array  # The log-prior density of the particles
+    particles: StateWithLogLikelihood
+    loglikelihood: Array
+    loglikelihood_birth: Array
     update_info: NamedTuple
-
-
-class StateWithLogLikelihood(NamedTuple):
-    """State container that partitions out the loglikelihood and logprior.
-
-    This intermediate construction wraps around the usual State of an MCMC chain
-    so that the loglikelihood and logprior can be efficiently recorded, a
-    necessary step for the Parition function reconstruction that Nested
-    Sampling builds
-
-
-    Attributes
-    ----------
-    position
-        A PyTree of arrays representing the current positions of the particles.
-        Each leaf array has a leading dimension corresponding to the number of particles.
-    logprior
-        An array of log-prior density values evaluated at the particle positions.
-        Shape: (n_particles,)
-    loglikelihood
-        An array of log-likelihood values evaluated at the particle positions.
-        Shape: (n_particles,)
-    """
-
-    position: ArrayLikeTree  # Current positions of particles in the inner kernel
-    logdensity: Array  # Log-prior values for particles in the inner kernel
-    loglikelihood: Array  # Log-likelihood values for particles in the inner kernel
 
 
 def init_state_strategy(
@@ -148,7 +130,7 @@ def init_state_strategy(
 
     Returns
     -------
-    PartitionedState
+    StateWithLogLikelihood
         The initialized state containing positions, log-prior, and log-likelihood.
     """
     logprior_values = logprior_fn(position)
@@ -157,7 +139,7 @@ def init_state_strategy(
 
 
 def init(
-    particles: ArrayLikeTree,
+    positions: ArrayLikeTree,
     init_state_fn: Callable,
     loglikelihood_birth: Array = -jnp.nan,
     logX: Optional[Array] = 0.0,
@@ -167,12 +149,12 @@ def init(
 
     Parameters
     ----------
-    particles
-        An initial set of particles (PyTree of arrays) drawn from the prior
+    positions
+        An initial set of positions (PyTree of arrays) drawn from the prior
         distribution. The leading dimension of each leaf array must be equal to
-        the number of particles.
+        the number of positions.
     init_state_fn
-        A function that initializes a StateWithLogLikelihood from particles.
+        A function that initializes a StateWithLogLikelihood from positions.
     loglikelihood_birth
         The initial log-likelihood birth threshold. Defaults to -NaN, which
         implies no initial likelihood constraint beyond the prior.
@@ -186,20 +168,16 @@ def init(
     NSState
         The initial state of the Nested Sampler.
     """
-    state = init_state_fn(particles)
-    loglikelihood = state.loglikelihood
-    loglikelihood_birth = loglikelihood_birth * jnp.ones_like(loglikelihood)
-    logprior = state.logdensity
-    dtype = loglikelihood.dtype
+    state = init_state_fn(positions)
+    dtype = state.loglikelihood.dtype
+    loglikelihood_birth_arr = loglikelihood_birth * jnp.ones_like(state.loglikelihood)
     logX = jnp.array(logX, dtype=dtype)
     logZ = jnp.array(logZ, dtype=dtype)
-    logZ_live = logmeanexp(loglikelihood) + logX
+    logZ_live = logmeanexp(state.loglikelihood) + logX
     inner_kernel_params: Dict = {}
     return NSState(
-        particles,
-        loglikelihood,
-        loglikelihood_birth,
-        logprior,
+        state,
+        loglikelihood_birth_arr,
         logX,
         logZ,
         logZ_live,
@@ -256,18 +234,11 @@ def build_kernel(
         rng_key, delete_fn_key = jax.random.split(rng_key)
         dead_idx, target_update_idx, start_idx = delete_fn(delete_fn_key, state)
         dead_particles = jax.tree.map(lambda x: x[dead_idx], state.particles)
-        dead_loglikelihood = state.loglikelihood[dead_idx]
-        dead_loglikelihood_birth = state.loglikelihood_birth[dead_idx]
-        dead_logprior = state.logprior[dead_idx]
 
         # Resample the live particles
-        loglikelihood_0 = dead_loglikelihood.max()
-        rng_key, sample_key = jax.random.split(rng_key)
-        sample_keys = jax.random.split(sample_key, len(start_idx))
-        particles = jax.tree.map(lambda x: x[start_idx], state.particles)
-        logprior = state.logprior[start_idx]
-        loglikelihood = state.loglikelihood[start_idx]
-        inner_state = StateWithLogLikelihood(particles, logprior, loglikelihood)
+        loglikelihood_0 = dead_particles.loglikelihood.max()
+        sample_keys = jax.random.split(rng_key, len(start_idx))
+        inner_state = jax.tree.map(lambda x: x[start_idx], state.particles)
         new_inner_state, inner_update_info = inner_kernel(
             sample_keys,
             inner_state,
@@ -276,30 +247,27 @@ def build_kernel(
         )
 
         # Update the particles
-        particles = jax.tree_util.tree_map(
+        new_particles = jax.tree_util.tree_map(
             lambda p, n: p.at[target_update_idx].set(n),
             state.particles,
-            new_inner_state.position,
+            new_inner_state,
         )
-        loglikelihood = state.loglikelihood.at[target_update_idx].set(
-            new_inner_state.loglikelihood
-        )
-        loglikelihood_birth = state.loglikelihood_birth.at[target_update_idx].set(
+        new_loglikelihood_birth = state.loglikelihood_birth.at[target_update_idx].set(
             loglikelihood_0
         )
-        logprior = state.logprior.at[target_update_idx].set(new_inner_state.logdensity)
 
         # Update the run-time information
         logX, logZ, logZ_live = update_ns_runtime_info(
-            state.logX, state.logZ, loglikelihood, dead_loglikelihood
+            state.logX, state.logZ, new_particles.loglikelihood, dead_particles.loglikelihood
         )
 
+        # Extract dead particle birth likelihoods
+        dead_loglikelihood_birth = state.loglikelihood_birth[dead_idx]
+
         # Return updated state and info
-        state = NSState(
-            particles,
-            loglikelihood,
-            loglikelihood_birth,
-            logprior,
+        new_state = NSState(
+            new_particles,
+            new_loglikelihood_birth,
             logX,
             logZ,
             logZ_live,
@@ -307,12 +275,11 @@ def build_kernel(
         )
         info = NSInfo(
             dead_particles,
-            dead_loglikelihood,
+            dead_particles.loglikelihood,
             dead_loglikelihood_birth,
-            dead_logprior,
             inner_update_info,
         )
-        return state, info
+        return new_state, info
 
     return kernel
 
@@ -350,7 +317,7 @@ def delete_fn(
         - `start_idx`: An array of indices corresponding to the particles
             selected for initialization.
     """
-    loglikelihood = state.loglikelihood
+    loglikelihood = state.particles.loglikelihood
     neg_dead_loglikelihood, dead_idx = jax.lax.top_k(-loglikelihood, num_delete)
     constraint_loglikelihood = loglikelihood > -neg_dead_loglikelihood.min()
     weights = jnp.array(constraint_loglikelihood, dtype=loglikelihood.dtype)

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -136,8 +136,9 @@ def init_state_strategy(
     """
     logprior_values = logprior_fn(position)
     loglikelihood_values = loglikelihood_fn(position)
+    loglikelihood_birth_values = loglikelihood_birth * jnp.ones_like(loglikelihood_values)
     return StateWithLogLikelihood(
-        position, logprior_values, loglikelihood_values, loglikelihood_birth
+        position, logprior_values, loglikelihood_values, loglikelihood_birth_values
     )
 
 

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -56,11 +56,15 @@ class StateWithLogLikelihood(NamedTuple):
         The log-prior density value of the particle.
     loglikelihood
         The log-likelihood value of the particle.
+    loglikelihood_birth
+        The log-likelihood threshold that this particle was required to exceed
+        when it was sampled (i.e., its birth likelihood contour).
     """
 
     position: ArrayLikeTree
     logdensity: Array
     loglikelihood: Array
+    loglikelihood_birth: Array
 
 
 class NSState(NamedTuple):
@@ -70,9 +74,7 @@ class NSState(NamedTuple):
     ----------
     particles
         StateWithLogLikelihood containing the current live particles.
-    loglikelihood_birth
-        An array storing the log-likelihood threshold that each current live
-        particle was required to exceed when it was "born" (i.e., sampled).
+        Includes position, logdensity, loglikelihood, and loglikelihood_birth.
     logX
         The log of the current prior volume estimate.
     logZ
@@ -84,7 +86,6 @@ class NSState(NamedTuple):
     """
 
     particles: StateWithLogLikelihood
-    loglikelihood_birth: Array
     logX: Array
     logZ: Array
     logZ_live: Array
@@ -98,21 +99,21 @@ class NSInfo(NamedTuple):
     ----------
     particles
         The StateWithLogLikelihood of particles that were marked as "dead" (replaced).
-        Contains position, logdensity, and loglikelihood.
-    loglikelihood_birth
-        The birth log-likelihood thresholds of the dead particles.
+        Contains position, logdensity, loglikelihood, and loglikelihood_birth.
     update_info
         A NamedTuple (or any PyTree) containing information from the update step
         (inner kernel) used to generate new live particles.
     """
 
     particles: StateWithLogLikelihood
-    loglikelihood_birth: Array
     update_info: NamedTuple
 
 
 def init_state_strategy(
-    position: ArrayLikeTree, logprior_fn: Callable, loglikelihood_fn: Callable
+    position: ArrayLikeTree,
+    logprior_fn: Callable,
+    loglikelihood_fn: Callable,
+    loglikelihood_birth: Array = jnp.nan,
 ) -> StateWithLogLikelihood:
     """The default initialisation strategy for each state.
 
@@ -125,21 +126,26 @@ def init_state_strategy(
         A function that computes the log-prior density for a single particle.
     loglikelihood
         A function that computes the log-likelihood for a single particle.
+    loglikelihood_birth
+        The log-likelihood threshold that the particle must exceed. Defaults to NaN.
 
     Returns
     -------
     StateWithLogLikelihood
-        The initialized state containing positions, log-prior, and log-likelihood.
+        The initialized state containing positions, log-prior, log-likelihood, and birth likelihood.
     """
     logprior_values = logprior_fn(position)
     loglikelihood_values = loglikelihood_fn(position)
-    return StateWithLogLikelihood(position, logprior_values, loglikelihood_values)
+    # loglikelihood_birth is already broadcast to the right shape by the caller
+    return StateWithLogLikelihood(
+        position, logprior_values, loglikelihood_values, loglikelihood_birth
+    )
 
 
 def init(
     positions: ArrayLikeTree,
     init_state_fn: Callable,
-    loglikelihood_birth: Array = -jnp.nan,
+    loglikelihood_birth: Array = jnp.nan,
     logX: Optional[Array] = 0.0,
     logZ: Optional[Array] = -jnp.inf,
 ) -> NSState:
@@ -154,7 +160,7 @@ def init(
     init_state_fn
         A function that initializes a StateWithLogLikelihood from positions.
     loglikelihood_birth
-        The initial log-likelihood birth threshold. Defaults to -NaN, which
+        The initial log-likelihood birth threshold. Defaults to NaN, which
         implies no initial likelihood constraint beyond the prior.
     logX
         The initial log prior volume estimate. Defaults to 0.0.
@@ -166,16 +172,19 @@ def init(
     NSState
         The initial state of the Nested Sampler.
     """
-    state = init_state_fn(positions)
+    # Broadcast loglikelihood_birth to have a batch dimension for vmap compatibility
+    # First, get the number of particles from positions
+    num_particles = jax.tree_util.tree_flatten(positions)[0][0].shape[0]
+    loglikelihood_birth_array = loglikelihood_birth * jnp.ones(num_particles)
+
+    state = init_state_fn(positions, loglikelihood_birth=loglikelihood_birth_array)
     dtype = state.loglikelihood.dtype
-    loglikelihood_birth_arr = loglikelihood_birth * jnp.ones_like(state.loglikelihood)
     logX = jnp.array(logX, dtype=dtype)
     logZ = jnp.array(logZ, dtype=dtype)
     logZ_live = logmeanexp(state.loglikelihood) + logX
     inner_kernel_params: Dict = {}
     return NSState(
         state,
-        loglikelihood_birth_arr,
         logX,
         logZ,
         logZ_live,
@@ -250,22 +259,15 @@ def build_kernel(
             state.particles,
             new_inner_state,
         )
-        new_loglikelihood_birth = state.loglikelihood_birth.at[target_update_idx].set(
-            loglikelihood_0
-        )
 
         # Update the run-time information
         logX, logZ, logZ_live = update_ns_runtime_info(
             state.logX, state.logZ, new_particles.loglikelihood, dead_particles.loglikelihood
         )
 
-        # Extract dead particle birth likelihoods
-        dead_loglikelihood_birth = state.loglikelihood_birth[dead_idx]
-
         # Return updated state and info
         new_state = NSState(
             new_particles,
-            new_loglikelihood_birth,
             logX,
             logZ,
             logZ_live,
@@ -273,7 +275,6 @@ def build_kernel(
         )
         info = NSInfo(
             dead_particles,
-            dead_loglikelihood_birth,
             inner_update_info,
         )
         return new_state, info

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -136,7 +136,6 @@ def init_state_strategy(
     """
     logprior_values = logprior_fn(position)
     loglikelihood_values = loglikelihood_fn(position)
-    # loglikelihood_birth is already broadcast to the right shape by the caller
     return StateWithLogLikelihood(
         position, logprior_values, loglikelihood_values, loglikelihood_birth
     )
@@ -172,11 +171,7 @@ def init(
     NSState
         The initial state of the Nested Sampler.
     """
-    # Broadcast loglikelihood_birth to have a batch dimension for vmap compatibility
-    # First, get the number of particles from positions
-    num_particles = jax.tree_util.tree_flatten(positions)[0][0].shape[0]
-    loglikelihood_birth_array = loglikelihood_birth * jnp.ones(num_particles)
-
+    loglikelihood_birth_array = loglikelihood_birth * jnp.ones(len(positions))
     state = init_state_fn(positions, loglikelihood_birth=loglikelihood_birth_array)
     dtype = state.loglikelihood.dtype
     logX = jnp.array(logX, dtype=dtype)

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -37,7 +37,7 @@ from jax.scipy.special import logsumexp
 
 from blackjax.types import Array, ArrayLikeTree, ArrayTree, PRNGKey
 
-__all__ = ["init", "build_kernel", "NSState", "NSInfo", "delete_fn"]
+__all__ = ["init", "build_kernel", "NSState", "NSInfo", "StateWithLogLikelihood", "delete_fn"]
 
 
 class StateWithLogLikelihood(NamedTuple):
@@ -75,20 +75,11 @@ class NSState(NamedTuple):
     particles
         StateWithLogLikelihood containing the current live particles.
         Includes position, logdensity, loglikelihood, and loglikelihood_birth.
-    logX
-        The log of the current prior volume estimate.
-    logZ
-        The accumulated log evidence estimate from the "dead" points.
-    logZ_live
-        The current estimate of the log evidence contribution from the live points.
     inner_kernel_params
         A dictionary of parameters for the inner kernel.
     """
 
     particles: StateWithLogLikelihood
-    logX: Array
-    logZ: Array
-    logZ_live: Array
     inner_kernel_params: Dict
 
 
@@ -146,8 +137,6 @@ def init(
     positions: ArrayLikeTree,
     init_state_fn: Callable,
     loglikelihood_birth: Array = jnp.nan,
-    logX: Optional[Array] = 0.0,
-    logZ: Optional[Array] = -jnp.inf,
 ) -> NSState:
     """Initializes the Nested Sampler state.
 
@@ -162,10 +151,6 @@ def init(
     loglikelihood_birth
         The initial log-likelihood birth threshold. Defaults to NaN, which
         implies no initial likelihood constraint beyond the prior.
-    logX
-        The initial log prior volume estimate. Defaults to 0.0.
-    logZ
-        The initial log evidence estimate. Defaults to -inf.
 
     Returns
     -------
@@ -174,18 +159,8 @@ def init(
     """
     loglikelihood_birth_array = loglikelihood_birth * jnp.ones(len(positions))
     state = init_state_fn(positions, loglikelihood_birth=loglikelihood_birth_array)
-    dtype = state.loglikelihood.dtype
-    logX = jnp.array(logX, dtype=dtype)
-    logZ = jnp.array(logZ, dtype=dtype)
-    logZ_live = logmeanexp(state.loglikelihood) + logX
     inner_kernel_params: Dict = {}
-    return NSState(
-        state,
-        logX,
-        logZ,
-        logZ_live,
-        inner_kernel_params,
-    )
+    return NSState(state, inner_kernel_params)
 
 
 def build_kernel(
@@ -239,14 +214,11 @@ def build_kernel(
         dead_particles = jax.tree.map(lambda x: x[dead_idx], state.particles)
 
         # Resample the live particles
-        loglikelihood_0 = dead_particles.loglikelihood.max()
         sample_keys = jax.random.split(rng_key, len(start_idx))
         inner_state = jax.tree.map(lambda x: x[start_idx], state.particles)
+        loglikelihood_0 = dead_particles.loglikelihood.max()
         new_inner_state, inner_update_info = inner_kernel(
-            sample_keys,
-            inner_state,
-            loglikelihood_0,
-            state.inner_kernel_params,
+            sample_keys, inner_state, loglikelihood_0, state.inner_kernel_params
         )
 
         # Update the particles
@@ -256,17 +228,9 @@ def build_kernel(
             new_inner_state,
         )
 
-        # Update the run-time information
-        logX, logZ, logZ_live = update_ns_runtime_info(
-            state.logX, state.logZ, new_particles.loglikelihood, dead_particles.loglikelihood
-        )
-
         # Return updated state and info
         new_state = NSState(
             new_particles,
-            logX,
-            logZ,
-            logZ_live,
             state.inner_kernel_params,
         )
         info = NSInfo(
@@ -327,25 +291,3 @@ def delete_fn(
     return dead_idx, target_update_idx, start_idx
 
 
-def update_ns_runtime_info(
-    logX: Array, logZ: Array, loglikelihood: Array, dead_loglikelihood: Array
-) -> tuple[Array, Array, Array]:
-    num_particles = len(loglikelihood)
-    num_deleted = len(dead_loglikelihood)
-    num_live = jnp.arange(
-        num_particles, num_particles - num_deleted, -1, dtype=loglikelihood.dtype
-    )
-    delta_logX = -1 / num_live
-    logX = logX + jnp.cumsum(delta_logX)
-    log_delta_X = logX + jnp.log(1 - jnp.exp(delta_logX))
-    log_delta_Z = dead_loglikelihood + log_delta_X
-
-    delta_logZ = logsumexp(log_delta_Z)
-    logZ = jnp.logaddexp(logZ, delta_logZ)
-    logZ_live = logmeanexp(loglikelihood) + logX[-1]
-    return logX[-1], logZ, logZ_live
-
-
-def logmeanexp(x: Array) -> Array:
-    n = jnp.array(x.shape[0], dtype=x.dtype)
-    return logsumexp(x) - jnp.log(n)

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -98,8 +98,7 @@ class NSInfo(NamedTuple):
     ----------
     particles
         The StateWithLogLikelihood of particles that were marked as "dead" (replaced).
-    loglikelihood
-        The log-likelihood values of the dead particles (extracted for evidence calculation).
+        Contains position, logdensity, and loglikelihood.
     loglikelihood_birth
         The birth log-likelihood thresholds of the dead particles.
     update_info
@@ -108,7 +107,6 @@ class NSInfo(NamedTuple):
     """
 
     particles: StateWithLogLikelihood
-    loglikelihood: Array
     loglikelihood_birth: Array
     update_info: NamedTuple
 
@@ -275,7 +273,6 @@ def build_kernel(
         )
         info = NSInfo(
             dead_particles,
-            dead_particles.loglikelihood,
             dead_loglikelihood_birth,
             inner_update_info,
         )

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -57,9 +57,6 @@ class NSState(NamedTuple):
         This is used for reconstructing the nested sampling path.
     logprior
         An array of log-prior values, one for each live particle.
-    pid
-        Particle ID. An array of integers tracking the identity or lineage of
-        particles, primarily for diagnostic purposes.
     logX
         The log of the current prior volume estimate.
     logZ
@@ -74,7 +71,6 @@ class NSState(NamedTuple):
     loglikelihood: Array  # The log-likelihood of the particles
     loglikelihood_birth: Array  # The log-likelihood threshold at particle birth
     logprior: Array  # The log-prior density of the particles
-    pid: Array  # particle IDs
     logX: Array  # The current log-volume estimate
     logZ: Array  # The accumulated evidence estimate
     logZ_live: Array  # The current evidence estimate
@@ -194,7 +190,6 @@ def init(
     loglikelihood = state.loglikelihood
     loglikelihood_birth = loglikelihood_birth * jnp.ones_like(loglikelihood)
     logprior = state.logdensity
-    pid = jnp.arange(len(loglikelihood), dtype=jnp.int32)
     dtype = loglikelihood.dtype
     logX = jnp.array(logX, dtype=dtype)
     logZ = jnp.array(logZ, dtype=dtype)
@@ -205,7 +200,6 @@ def init(
         loglikelihood,
         loglikelihood_birth,
         logprior,
-        pid,
         logX,
         logZ,
         logZ_live,
@@ -294,7 +288,6 @@ def build_kernel(
             loglikelihood_0
         )
         logprior = state.logprior.at[target_update_idx].set(new_inner_state.logdensity)
-        pid = state.pid.at[target_update_idx].set(state.pid[start_idx])
 
         # Update the run-time information
         logX, logZ, logZ_live = update_ns_runtime_info(
@@ -307,7 +300,6 @@ def build_kernel(
             loglikelihood,
             loglikelihood_birth,
             logprior,
-            pid,
             logX,
             logZ,
             logZ_live,

--- a/blackjax/ns/from_mcmc.py
+++ b/blackjax/ns/from_mcmc.py
@@ -55,9 +55,9 @@ def build_kernel(
 
     def constrained_mcmc_step_fn(rng_key, state, loglikelihood_0, **params):
         rng_key, prop_key = jax.random.split(rng_key, 2)
-        mcmc_state = mcmc_init_fn(rng_key, state.position, state.logprior)
+        mcmc_state = mcmc_init_fn(rng_key, state.position, state.logdensity)
         new_mcmc_state, mcmc_info = mcmc_step_fn(prop_key, mcmc_state, **params)
-        new_state = init_state_fn(new_mcmc_state.position)
+        new_state = init_state_fn(new_mcmc_state.position, loglikelihood_birth=loglikelihood_0)
         new_state = jax.lax.cond(
             new_state.loglikelihood > loglikelihood_0,
             lambda _: new_state,

--- a/blackjax/ns/integrator.py
+++ b/blackjax/ns/integrator.py
@@ -1,0 +1,118 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Evidence integration for Nested Sampling.
+
+This module provides utilities for tracking the evidence integral during
+a Nested Sampling run. The NSIntegrator accumulates statistics as the algorithm
+compresses the prior volume, computing the marginal likelihood (evidence),
+information gain (entropy), and related quantities.
+"""
+
+from typing import NamedTuple
+
+import jax.numpy as jnp
+from jax.scipy.special import logsumexp
+
+from blackjax.ns.base import NSInfo, NSState
+from blackjax.types import Array
+
+__all__ = ["NSIntegrator", "init_integrator", "update_integrator"]
+
+
+class NSIntegrator(NamedTuple):
+    """Integrator for computing the evidence integral in Nested Sampling.
+
+    This accumulates statistics over the course of a Nested Sampling run,
+    computing the evidence (marginal likelihood) and related quantities
+    from the history of dead particles. These are derived quantities that
+    can be reconstructed from the dead particle history.
+
+    Attributes
+    ----------
+    logX
+        The log of the current prior volume estimate.
+    logZ
+        The accumulated log evidence estimate from the "dead" points.
+    logZ_live
+        The current estimate of the log evidence contribution from the live points.
+    """
+
+    logX: Array
+    logZ: Array
+    logZ_live: Array
+
+
+def init_integrator(live_state: NSState) -> NSIntegrator:
+    """Initialize the evidence integrator from the initial live points.
+
+    Parameters
+    ----------
+    live_state
+        The initial NSState containing the live particles.
+
+    Returns
+    -------
+    NSIntegrator
+        The initial integrator with logX=0, logZ=-inf, and logZ_live computed
+        from the initial live points.
+    """
+    dtype = live_state.particles.loglikelihood.dtype
+    logX = jnp.array(0.0, dtype=dtype)
+    logZ = jnp.array(-jnp.inf, dtype=dtype)
+    logZ_live = _logmeanexp(live_state.particles.loglikelihood) + logX
+    return NSIntegrator(logX, logZ, logZ_live)
+
+
+def update_integrator(
+    integrator: NSIntegrator, live_state: NSState, dead_info: NSInfo
+) -> NSIntegrator:
+    """Update the evidence integrator after a Nested Sampling step.
+
+    Parameters
+    ----------
+    integrator
+        The current integrator state.
+    live_state
+        The updated live state after the NS step.
+    dead_info
+        Information about the particles that died in this step.
+
+    Returns
+    -------
+    NSIntegrator
+        The updated integrator with new logX, logZ, and logZ_live.
+    """
+    loglikelihood = live_state.particles.loglikelihood
+    dead_loglikelihood = dead_info.particles.loglikelihood
+
+    num_particles = len(loglikelihood)
+    num_deleted = len(dead_loglikelihood)
+    num_live = jnp.arange(
+        num_particles, num_particles - num_deleted, -1, dtype=loglikelihood.dtype
+    )
+    delta_logX = -1 / num_live
+    logX = integrator.logX + jnp.cumsum(delta_logX)
+    log_delta_X = logX + jnp.log(1 - jnp.exp(delta_logX))
+    log_delta_Z = dead_loglikelihood + log_delta_X
+
+    delta_logZ = logsumexp(log_delta_Z)
+    logZ = jnp.logaddexp(integrator.logZ, delta_logZ)
+    logZ_live = _logmeanexp(loglikelihood) + logX[-1]
+    return NSIntegrator(logX[-1], logZ, logZ_live)
+
+
+def _logmeanexp(x: Array) -> Array:
+    """Compute log(mean(exp(x))) in a numerically stable way."""
+    n = jnp.array(x.shape[0], dtype=x.dtype)
+    return logsumexp(x) - jnp.log(n)

--- a/blackjax/ns/nss.py
+++ b/blackjax/ns/nss.py
@@ -93,7 +93,7 @@ def build_kernel(
 
         def slice_fn(t) -> tuple[StateWithLogLikelihood, bool]:
             x, step_accepted = stepper_fn(state.position, d, t)
-            new_state = init_state_fn(x)
+            new_state = init_state_fn(x, loglikelihood_birth=loglikelihood_0)
             in_contour = new_state.loglikelihood > loglikelihood_0
             is_accepted = in_contour & step_accepted
             return new_state, is_accepted
@@ -196,6 +196,7 @@ def as_top_level_api(
 
     def init_fn(position, rng_key=None):
         # Vectorize the functions for parallel evaluation over particles
+        # vmap maps over positional args, keyword args (like loglikelihood_birth) are broadcast
         return init(
             position,
             init_state_fn=jax.vmap(init_state_fn),

--- a/blackjax/ns/nss.py
+++ b/blackjax/ns/nss.py
@@ -69,7 +69,7 @@ def compute_covariance_from_particles(
     inner_kernel_params: Optional[Dict[str, ArrayTree]] = None,
 ) -> Dict[str, ArrayTree]:
     """Compute empirical covariance from current particles for direction proposal."""
-    return {"cov": jnp.atleast_2d(particles_covariance_matrix(state.particles))}
+    return {"cov": jnp.atleast_2d(particles_covariance_matrix(state.particles.position))}
 
 
 def build_kernel(

--- a/blackjax/ns/utils.py
+++ b/blackjax/ns/utils.py
@@ -239,9 +239,8 @@ def finalise(live: NSState, dead: list[NSInfo]) -> NSInfo:
     all_pytrees_to_combine = dead + [
         NSInfo(
             live.particles,
-            live.loglikelihood,
+            live.particles.loglikelihood,
             live.loglikelihood_birth,
-            live.logprior,
             dead[-1].update_info,
         )
     ]

--- a/blackjax/ns/utils.py
+++ b/blackjax/ns/utils.py
@@ -91,7 +91,7 @@ def compute_num_live(info: NSInfo) -> Array:
         was considered "dead".
     """
     birth_logL = info.loglikelihood_birth
-    death_logL = info.loglikelihood
+    death_logL = info.particles.loglikelihood
 
     birth_events = jnp.column_stack(
         (birth_logL, jnp.ones_like(birth_logL, dtype=jnp.int32))
@@ -147,12 +147,12 @@ def logX(rng_key: PRNGKey, dead_info: NSInfo, shape: int = 100) -> tuple[Array, 
           `dX_i` is approximately `X_i - X_{i+1}`.
     """
     rng_key, subkey = jax.random.split(rng_key)
-    min_val = jnp.finfo(dead_info.loglikelihood.dtype).tiny
+    min_val = jnp.finfo(dead_info.particles.loglikelihood.dtype).tiny
     r = jnp.log(
         jax.random.uniform(
             subkey,
-            shape=(dead_info.loglikelihood.shape[0], shape),
-            dtype=dead_info.loglikelihood.dtype,
+            shape=(dead_info.particles.loglikelihood.shape[0], shape),
+            dtype=dead_info.particles.loglikelihood.dtype,
         ).clip(min_val, 1 - min_val)
     )
 
@@ -201,12 +201,12 @@ def log_weights(
         An array of log importance weights, shape `(num_dead_particles, *shape)`.
         The original order of particles in `dead_info` is preserved.
     """
-    sort_indices = jnp.argsort(dead_info.loglikelihood)
+    sort_indices = jnp.argsort(dead_info.particles.loglikelihood)
     unsort_indices = jnp.empty_like(sort_indices)
     unsort_indices = unsort_indices.at[sort_indices].set(jnp.arange(len(sort_indices)))
     dead_info_sorted = jax.tree.map(lambda x: x[sort_indices], dead_info)
     _, log_dX = logX(rng_key, dead_info_sorted, shape)
-    log_w = log_dX + beta * dead_info_sorted.loglikelihood[..., jnp.newaxis]
+    log_w = log_dX + beta * dead_info_sorted.particles.loglikelihood[..., jnp.newaxis]
     return log_w[unsort_indices]
 
 
@@ -239,7 +239,6 @@ def finalise(live: NSState, dead: list[NSInfo]) -> NSInfo:
     all_pytrees_to_combine = dead + [
         NSInfo(
             live.particles,
-            live.particles.loglikelihood,
             live.loglikelihood_birth,
             dead[-1].update_info,
         )
@@ -308,7 +307,7 @@ def sample(rng_key: PRNGKey, dead_info_map: NSInfo, shape: int = 1000) -> ArrayT
     logw = log_weights(rng_key, dead_info_map).mean(axis=-1)
     indices = jax.random.choice(
         rng_key,
-        dead_info_map.loglikelihood.shape[0],
+        dead_info_map.particles.loglikelihood.shape[0],
         p=jnp.exp(logw.squeeze() - jnp.max(logw)),
         shape=(shape,),
         replace=True,

--- a/blackjax/ns/utils.py
+++ b/blackjax/ns/utils.py
@@ -90,7 +90,7 @@ def compute_num_live(info: NSInfo) -> Array:
         points `m*_i` when the j-th particle (in the sorted list of dead particles)
         was considered "dead".
     """
-    birth_logL = info.loglikelihood_birth
+    birth_logL = info.particles.loglikelihood_birth
     death_logL = info.particles.loglikelihood
 
     birth_events = jnp.column_stack(
@@ -239,7 +239,6 @@ def finalise(live: NSState, dead: list[NSInfo]) -> NSInfo:
     all_pytrees_to_combine = dead + [
         NSInfo(
             live.particles,
-            live.loglikelihood_birth,
             dead[-1].update_info,
         )
     ]

--- a/docs/examples/nested_sampling.py
+++ b/docs/examples/nested_sampling.py
@@ -4,6 +4,7 @@ import tqdm
 from jax.scipy.linalg import inv, solve
 
 import blackjax
+from blackjax.ns.integrator import NSIntegrator, init_integrator, update_integrator
 from blackjax.ns.utils import finalise, log_weights
 
 # jax.config.update("jax_enable_x64", True)
@@ -92,16 +93,18 @@ initial_particles = jax.random.multivariate_normal(
 # and run it in a python loop
 
 live = algo.init(initial_particles)
+integrator = init_integrator(live)
 step_fn = jax.jit(algo.step)
 dead = []
 # with jax.disable_jit():
 for _ in tqdm.trange(1000):
     # We track the estimate of the evidence in the live points as logZ_live, and the accumulated sum across all steps in logZ
     # this gives a handy termination that allows us to stop early
-    if live.logZ_live - live.logZ < -3:  # type: ignore[attr-defined]
+    if integrator.logZ_live - integrator.logZ < -3:
         break
     rng_key, subkey = jax.random.split(rng_key, 2)
     live, dead_info = step_fn(subkey, live)
+    integrator = update_integrator(integrator, live, dead_info)
     dead.append(dead_info)
 
 # It is now not too bad to remap the list of NSInfos into a single instance
@@ -116,5 +119,5 @@ logw = log_weights(rng_key, nested_samples)
 logZs = jax.scipy.special.logsumexp(logw, axis=0)
 
 print(f"Analytic evidence: {log_analytic_evidence:.2f}")
-print(f"Runtime evidence: {live.logZ:.2f}")  # type: ignore[attr-defined]
+print(f"Integrated evidence: {integrator.logZ:.2f}")
 print(f"Estimated evidence: {logZs.mean():.2f} +- {logZs.std():.2f}")


### PR DESCRIPTION
This PR introduces `NSIntegrator` to separate evidence tracking from the live point state, **dramatically simplifying the base NS kernel**.

## Code Simplification

**105 net lines removed** from `base.py`:
- ✅ Evidence integration logic completely removed from kernel
- ✅ NSState reduced to only essential fields (particles + params)
- ✅ No more coupling between stepping and evidence tracking

The kernel now focuses purely on particle replacement, with evidence tracking handled externally via `NSIntegrator`.

## New Architecture

**NSState** (minimal state for stepping):
```python
class NSState(NamedTuple):
    particles: StateWithLogLikelihood  # Current live points
    inner_kernel_params: Dict          # Kernel parameters
```

**NSIntegrator** (external evidence tracking):
```python
class NSIntegrator(NamedTuple):
    logX: Array      # Current prior volume
    logZ: Array      # Accumulated evidence
    logZ_live: Array # Evidence from live points
```

**NSInfo** (per-step information):
```python
class NSInfo(NamedTuple):
    particles: StateWithLogLikelihood  # Dead points from this step
    update_info: NamedTuple            # Inner kernel info
```

## Updated Interface

```python
import jax
import jax.numpy as jnp
import blackjax
from blackjax.ns.utils import finalise
from blackjax.ns.integrator import init_integrator, update_integrator
import tqdm

rng_key = jax.random.PRNGKey(0)

loglikelihood_fn = lambda x: jax.scipy.stats.multivariate_normal.logpdf(
    x, jnp.ones(5), jnp.eye(5)*0.01
)
logprior_fn = lambda x: jax.scipy.stats.multivariate_normal.logpdf(
    x, jnp.zeros(5), jnp.eye(5)
)

algo = blackjax.nss(
    logprior_fn=logprior_fn,
    loglikelihood_fn=loglikelihood_fn,
    num_delete=50,
    num_inner_steps=20,
)

rng_key, initialization_key = jax.random.split(rng_key)
live = algo.init(jax.random.normal(initialization_key, (1000, 5)))
integrator = init_integrator(live)
step = jax.jit(algo.step)

dead_points = []

with tqdm.tqdm(desc="Dead points", unit=" dead points") as pbar:
    while not (integrator.logZ_live - integrator.logZ < -3):
        rng_key, subkey = jax.random.split(rng_key)
        live, dead = step(subkey, live)
        integrator = update_integrator(integrator, live, dead)
        dead_points.append(dead)
        pbar.update(len(dead.particles.position))

ns_run = finalise(live, dead_points)
```

## Benefits

1. **Simpler kernel**: Pure particle replacement, no evidence bookkeeping
2. **Better JIT**: Step function doesn't carry cumulative state
3. **Explicit control**: Evidence tracking is visible and inspectable
4. **Flexible patterns**: Works naturally with scan/while_loop

## Migration

**Before** (state contains everything):
```python
live, dead = step(rng_key, live)
if live.logZ_live - live.logZ < -3:
    break
```

**After** (evidence tracked externally):
```python
live, dead = step(rng_key, live)
integrator = update_integrator(integrator, live, dead)
if integrator.logZ_live - integrator.logZ < -3:
    break
```