### PR TITLE
Reinstate internal adaptive and tuning

### DIFF
--- a/blackjax/mcmc/ss.py
+++ b/blackjax/mcmc/ss.py
@@ -34,7 +34,6 @@ import jax.numpy as jnp
 
 from blackjax.base import SamplingAlgorithm
 from blackjax.types import Array, ArrayLikeTree, ArrayTree, PRNGKey
-from blackjax.util import linear_map
 
 __all__ = [
     "SliceState",
@@ -303,20 +302,6 @@ def sample_direction_from_covariance(
 ) -> Array:
     """Generates a random direction vector, normalized, from a multivariate Gaussian.
 
-    This function generates a direction vector uniformly distributed on a hypersphere
-    by using the mathematical simplification:
-    1. Sample from standard multivariate normal N(0, I)
-    2. Normalize to unit vector (uniform on hypersphere)
-    3. Transform by S^(1/2) where S is the covariance matrix
-    4. Scale by 2*sqrt(d+2) to optimize for slice sampling
-
-    This is equivalent to sampling from N(0, S) and normalizing by Mahalanobis norm
-    but is more numerically stable and efficient.
-
-    The scaling factor 2*sqrt(d+2) corrects for two effects:
-    - Factor sqrt(d+2): Empirical covariance of uniform d-ball has Σ = R²/(d+2) I,
-      underestimating spatial extent by (d+2)
-    - Factor 2: Initial slice interval should span diameter (2R) not radius (R)
 
     Parameters
     ----------
@@ -332,12 +317,10 @@ def sample_direction_from_covariance(
         A normalized direction vector (1D array).
     """
     p, unravel_fn = jax.flatten_util.ravel_pytree(position)
-    u = jax.random.normal(rng_key, shape=p.shape, dtype=p.dtype)
-    u /= jnp.linalg.norm(u)
-    L = jnp.linalg.cholesky(cov).astype(p.dtype)
-    # dim = cov.shape[0]
-    L = L * 2
-    d = linear_map(L, u)
+    d = jax.random.normal(rng_key, shape=p.shape, dtype=p.dtype)
+    invcov = jnp.linalg.inv(cov)
+    norm = jnp.sqrt(jnp.einsum("...i,...ij,...j", d, invcov, d))
+    d = d / norm[..., None]
     return unravel_fn(d)
 
 

--- a/blackjax/mcmc/ss.py
+++ b/blackjax/mcmc/ss.py
@@ -321,6 +321,7 @@ def sample_direction_from_covariance(
     invcov = jnp.linalg.inv(cov)
     norm = jnp.sqrt(jnp.einsum("...i,...ij,...j", d, invcov, d))
     d = d / norm[..., None]
+    d *= 2
     return unravel_fn(d)
 
 

--- a/blackjax/mcmc/ss.py
+++ b/blackjax/mcmc/ss.py
@@ -335,8 +335,8 @@ def sample_direction_from_covariance(
     u = jax.random.normal(rng_key, shape=p.shape, dtype=p.dtype)
     u /= jnp.linalg.norm(u)
     L = jnp.linalg.cholesky(cov).astype(p.dtype)
-    dim = cov.shape[0]
-    L = L * 2 * jnp.sqrt(dim + 2)
+    # dim = cov.shape[0]
+    L = L * 2
     d = linear_map(L, u)
     return unravel_fn(d)
 

--- a/blackjax/ns/__init__.py
+++ b/blackjax/ns/__init__.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 """Nested Sampling Algorithms in BlackJAX.
 
-This subpackage provides implementations of Nested Sampling algorithms,
-including a base version and Nested Slice Sampling (NSS).
+This subpackage provides implementations of Nested Sampling algorithms.
 
 Nested Sampling is a Monte Carlo method for Bayesian computation, primarily
 used for evidence (marginal likelihood) calculation and posterior sampling.
@@ -24,18 +23,22 @@ complex likelihood landscapes.
 Available modules:
 ------------------
 - `base`: Provides core components for Nested Sampling.
+- `adaptive`: Implements Adaptive Nested Sampling, combining SMC tempering
 - `nss`: Implements Nested Slice Sampling, using Hit-and-Run Slice Sampling as
          the inner kernel with adaptive tuning of its proposal mechanism.
 - `integrator`: Provides NSIntegrator for tracking evidence integration.
 - `utils`: Contains utility functions for processing and analyzing Nested
            Sampling results.
+- `from_mcmc`: Utilities to build Nested Sampling algorithms from MCMC kernels.
 
 """
-from . import base, integrator, nss, utils
+from . import adaptive, base, from_mcmc, integrator, nss, utils
 
 __all__ = [
     "base",
+    "adaptive",
     "integrator",
     "nss",
     "utils",
+    "from_mcmc",
 ]

--- a/blackjax/ns/adaptive.py
+++ b/blackjax/ns/adaptive.py
@@ -34,7 +34,7 @@ class AdaptiveNSState(NamedTuple):
     """An extension of the base NSState to include inner kernel parameters.
 
     This state class extends the base Nested Sampling state by adding a
-    dictionary of parameters for the inner kernel and an integator to track
+    dictionary of parameters for the inner kernel and an integrator to track
     relevant values for the evidence computation.
 
     Attributes

--- a/blackjax/ns/adaptive.py
+++ b/blackjax/ns/adaptive.py
@@ -33,11 +33,15 @@ class AdaptiveNSState(NamedTuple):
     """An extension of the base NSState to include inner kernel parameters.
 
     This state class extends the base Nested Sampling state by adding a
-    dictionary of parameters for the inner kernel. These parameters can be
-    updated adaptively at each step of the Nested Sampling algorithm.
+    dictionary of parameters for the inner kernel and an integator to track
+    relevant values for the evidence computation.
 
     Attributes
     ----------
+    particles
+        The StateWithLogLikelihood of the current live particles.
+    integrator
+        The NSIntegrator instance that tracks evidence-related statistics.
     inner_kernel_params
         A dictionary of parameters for the inner kernel used to generate new
         particles during the Nested Sampling process.
@@ -75,7 +79,12 @@ def build_kernel(
         [NSState, NSInfo, Dict[str, ArrayTree]], Dict[str, ArrayTree]
     ],
 ) -> Callable:
-    """Build an adaptive Nested Sampling kernel."""
+    """Build an adaptive Nested Sampling kernel.
+
+    This function constructs a Nested Sampling kernel that incorporates
+    adaptive tuning of the inner kernel parameters based on the current state
+    of the sampler and the information from the previous update step.
+    """
 
     base_kernel = base_build_kernel(
         delete_fn,

--- a/blackjax/ns/adaptive.py
+++ b/blackjax/ns/adaptive.py
@@ -16,6 +16,7 @@
 This combines the SMC equivalent of Adaptive Tempering and inner kernel tuning in one file.
 """
 
+from functools import partial
 from typing import Callable, Dict, NamedTuple, Optional
 
 import jax.numpy as jnp
@@ -86,18 +87,16 @@ def build_kernel(
     of the sampler and the information from the previous update step.
     """
 
-    base_kernel = base_build_kernel(
-        delete_fn,
-        inner_kernel,
-    )
-
     def kernel(
         rng_key: PRNGKey, state: AdaptiveNSState
     ) -> tuple[AdaptiveNSState, NSInfo]:
         """Performs one step of adaptive Nested Sampling."""
-        new_state, info = base_kernel(
-            rng_key, state, inner_kernel_params=state.inner_kernel_params
+        adapted_kernel = base_build_kernel(
+            delete_fn,
+            partial(inner_kernel, **state.inner_kernel_params),
         )
+
+        new_state, info = adapted_kernel(rng_key, state)
 
         new_inner_kernel_params = update_inner_kernel_params_fn(
             new_state, info, new_state.inner_kernel_params

--- a/blackjax/ns/adaptive.py
+++ b/blackjax/ns/adaptive.py
@@ -1,0 +1,108 @@
+# Copyright 2020- The Blackjax Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Adaptive Nested Sampling for BlackJAX.
+
+This combines the SMC equivalent of Adaptive Tempering and inner kernel tuning in one file.
+"""
+
+from typing import Callable, Dict, NamedTuple, Optional
+
+import jax.numpy as jnp
+
+from blackjax.ns.base import NSInfo, NSState, StateWithLogLikelihood
+from blackjax.ns.base import build_kernel as base_build_kernel
+from blackjax.ns.base import init as base_init
+from blackjax.ns.integrator import NSIntegrator, init_integrator, update_integrator
+from blackjax.types import Array, ArrayLikeTree, ArrayTree, PRNGKey
+
+__all__ = ["init", "build_kernel"]
+
+
+class AdaptiveNSState(NamedTuple):
+    """An extension of the base NSState to include inner kernel parameters.
+
+    This state class extends the base Nested Sampling state by adding a
+    dictionary of parameters for the inner kernel. These parameters can be
+    updated adaptively at each step of the Nested Sampling algorithm.
+
+    Attributes
+    ----------
+    inner_kernel_params
+        A dictionary of parameters for the inner kernel used to generate new
+        particles during the Nested Sampling process.
+    """
+
+    particles: StateWithLogLikelihood
+    integrator: NSIntegrator
+    inner_kernel_params: Dict[str, ArrayTree]
+
+
+def init(
+    positions: ArrayLikeTree,
+    init_state_fn: Callable,
+    loglikelihood_birth: Array = jnp.nan,
+    update_inner_kernel_params_fn: Optional[Callable] = None,
+) -> AdaptiveNSState:
+    base_state = base_init(
+        positions, init_state_fn, loglikelihood_birth=loglikelihood_birth
+    )
+    integrator = init_integrator(base_state.particles)
+    inner_kernel_params = {}
+    if update_inner_kernel_params_fn is not None:
+        inner_kernel_params = update_inner_kernel_params_fn(base_state, None, {})
+    return AdaptiveNSState(
+        particles=base_state.particles,
+        inner_kernel_params=inner_kernel_params,
+        integrator=integrator,
+    )
+
+
+def build_kernel(
+    delete_fn: Callable,
+    inner_kernel: Callable,
+    update_inner_kernel_params_fn: Callable[
+        [NSState, NSInfo, Dict[str, ArrayTree]], Dict[str, ArrayTree]
+    ],
+) -> Callable:
+    """Build an adaptive Nested Sampling kernel."""
+
+    base_kernel = base_build_kernel(
+        delete_fn,
+        inner_kernel,
+    )
+
+    def kernel(
+        rng_key: PRNGKey, state: AdaptiveNSState
+    ) -> tuple[AdaptiveNSState, NSInfo]:
+        """Performs one step of adaptive Nested Sampling."""
+        new_state, info = base_kernel(
+            rng_key, state, inner_kernel_params=state.inner_kernel_params
+        )
+
+        new_inner_kernel_params = update_inner_kernel_params_fn(
+            new_state, info, new_state.inner_kernel_params
+        )
+        new_integrator_state = update_integrator(
+            state.integrator, new_state.particles, info.particles
+        )
+        return (
+            AdaptiveNSState(
+                particles=new_state.particles,
+                inner_kernel_params=new_inner_kernel_params,
+                integrator=new_integrator_state,
+            ),
+            info,
+        )
+
+    return kernel

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """"""
-from typing import Callable, Dict, NamedTuple
+from typing import Callable, NamedTuple
 
 import jax
 import jax.numpy as jnp
@@ -167,9 +167,7 @@ def build_kernel(
         `(rng_key, state, inner_kernel_params) -> (new_state, ns_info)`.
     """
 
-    def kernel(
-        rng_key: PRNGKey, state: NSState, inner_kernel_params: Dict
-    ) -> tuple[NSState, NSInfo]:
+    def kernel(rng_key: PRNGKey, state: NSState) -> tuple[NSState, NSInfo]:
         # Delete, and grab all the dead information
         rng_key, delete_fn_key = jax.random.split(rng_key)
         dead_idx, target_update_idx, start_idx = delete_fn(
@@ -182,7 +180,7 @@ def build_kernel(
         inner_state = jax.tree.map(lambda x: x[start_idx], state.particles)
         loglikelihood_0 = dead_particles.loglikelihood.max()
         new_inner_state, inner_update_info = inner_kernel(
-            sample_keys, inner_state, loglikelihood_0, inner_kernel_params
+            sample_keys, inner_state, loglikelihood_0
         )
 
         # Update the particles

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -26,6 +26,17 @@ class StateWithLogLikelihood(NamedTuple):
     """State of a particle in NS. Mostly dressing a conventional
     MCMC state with loglikelihood information. Positions are an ArrayTree
     where each leaf represents a variable from the posterior.
+
+    Attributes
+    ----------
+    position
+        The position of the particle (PyTree).
+    logdensity
+        The log-density of the particle under the prior (Array).
+    loglikelihood
+        The log-likelihood of the particle (Array).
+    loglikelihood_birth
+        The log-likelihood birth threshold for the particle (Array).
     """
 
     position: ArrayLikeTree

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -93,7 +93,7 @@ def init_state_strategy(
 
     Returns
     -------
-    NSState
+    StateWithLogLikelihood
         The initialized state containing positions, log-prior, log-likelihood, and birth likelihood.
     """
     logprior_values = logprior_fn(position)
@@ -157,7 +157,7 @@ def build_kernel(
         for new particle generation.
     inner_kernel
         This kernel function has the signature
-        `(rng_keys, inner_state, loglikelihood_0, params) -> (new_inner_state, inner_info)`,
+        `(rng_keys, inner_state, loglikelihood_0) -> (new_inner_state, inner_info)`,
         and is used to generate new particles.
 
     Returns

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -11,24 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Base components for Nested Sampling algorithms in BlackJAX.
-
-This module provides the fundamental data structures (`NSState`, `NSInfo`) and
-a basic, non-adaptive kernel for Nested Sampling. Nested Sampling is a
-Monte Carlo method primarily aimed at Bayesian evidence (marginal likelihood)
-computation and posterior sampling, particularly effective for multi-modal
-distributions.
-
-The core idea is to transform the multi-dimensional evidence integral into a
-one-dimensional integral over the prior volume, ordered by likelihood. This is
-achieved by iteratively replacing the point with the lowest likelihood among a
-set of "live" points with a new point sampled from the prior, subject to the
-constraint that its likelihood must be higher than the one just discarded.
-
-This base implementation uses a provided kernel to perform the constrained
-sampling.
-"""
-
+""""""
 from typing import Callable, Dict, NamedTuple
 
 import jax
@@ -40,6 +23,11 @@ __all__ = ["init", "build_kernel", "NSState", "NSInfo", "delete_fn"]
 
 
 class StateWithLogLikelihood(NamedTuple):
+    """State of a particle in NS. Mostly dressing a conventional
+    MCMC state with loglikelihood information. Positions are an ArrayTree
+    where each leaf represents a variable from the posterior.
+    """
+
     position: ArrayLikeTree
     logdensity: Array
     loglikelihood: Array
@@ -49,21 +37,8 @@ class StateWithLogLikelihood(NamedTuple):
 class NSState(NamedTuple):
     """State of the Nested Sampler.
 
-    Contains the current live particles with their positions, log-prior density,
-    log-likelihood values, and birth likelihood contours.
-
-    Attributes
-    ----------
-    position
-        A PyTree representing the position of the particles in parameter space.
-        The leading dimension corresponds to the number of particles.
-    logdensity
-        The log-prior density values of the particles.
-    loglikelihood
-        The log-likelihood values of the particles.
-    loglikelihood_birth
-        The log-likelihood thresholds that the particles were required to exceed
-        when they were sampled (i.e., their birth likelihood contours).
+    At the most basic level, this is just a wrapper around a StateWithLogLikelihood
+    however it is extended in other NS implementations.
     """
 
     particles: StateWithLogLikelihood
@@ -75,14 +50,13 @@ class NSInfo(NamedTuple):
     Attributes
     ----------
     particles
-        The NSState of particles that were marked as "dead" (replaced).
-        Contains position, logdensity, loglikelihood, and loglikelihood_birth.
+        The StateWithLogLikelihood of particles that were marked as "dead" (replaced).
     update_info
         A NamedTuple (or any PyTree) containing information from the update step
         (inner kernel) used to generate new live particles.
     """
 
-    particles: NSState
+    particles: StateWithLogLikelihood
     update_info: NamedTuple
 
 
@@ -159,21 +133,8 @@ def build_kernel(
 ) -> Callable:
     """Build a generic Nested Sampling kernel.
 
-    This kernel implements one step of the Nested Sampling algorithm. In each step:
-    1. A set of particles with the lowest log-likelihoods are identified and
-       marked as "dead" using `delete_fn`. The log-likelihood of the "worst"
-       of these dead particles (i.e., max among the lowest ones) defines the new
-       likelihood constraint `loglikelihood_0`.
-    2. Live particles are selected (typically with replacement from the remaining
-       live particles, determined by `delete_fn`) to act as starting points for
-       the updates.
-    3. These selected live particles are evolved using an kernel
-       `inner_kernel`. The sampling is constrained to the region where
-       `loglikelihood(new_particle) > loglikelihood_0`.
-    4. The newly generated particles replace particles marked for replacement,
-       (typically the ones that have just been deleted).
-    5. The prior volume `logX` and evidence `logZ` are updated based on the
-       number of deleted particles and their likelihoods.
+    This function creates a kernel for the Nested Sampling algorithm by combining
+    a particle deletion function and an inner kernel for generating new particles.
 
     Parameters
     ----------
@@ -268,7 +229,7 @@ def delete_fn(
     loglikelihood = state.loglikelihood
     neg_dead_loglikelihood, dead_idx = jax.lax.top_k(-loglikelihood, num_delete)
     constraint_loglikelihood = loglikelihood > -neg_dead_loglikelihood.min()
-    weights = jnp.array(constraint_loglikelihood, dtype=loglikelihood.dtype)
+    weights = jnp.array(constraint_loglikelihood)
     weights = jnp.where(weights.sum() > 0.0, weights, jnp.ones_like(weights))
     start_idx = jax.random.choice(
         rng_key,

--- a/blackjax/ns/base.py
+++ b/blackjax/ns/base.py
@@ -29,15 +29,21 @@ This base implementation uses a provided kernel to perform the constrained
 sampling.
 """
 
-from typing import Callable, Dict, NamedTuple, Optional
+from typing import Callable, Dict, NamedTuple
 
 import jax
 import jax.numpy as jnp
-from jax.scipy.special import logsumexp
 
-from blackjax.types import Array, ArrayLikeTree, ArrayTree, PRNGKey
+from blackjax.types import Array, ArrayLikeTree, PRNGKey
 
 __all__ = ["init", "build_kernel", "NSState", "NSInfo", "delete_fn"]
+
+
+class StateWithLogLikelihood(NamedTuple):
+    position: ArrayLikeTree
+    logdensity: Array
+    loglikelihood: Array
+    loglikelihood_birth: Array
 
 
 class NSState(NamedTuple):
@@ -60,10 +66,7 @@ class NSState(NamedTuple):
         when they were sampled (i.e., their birth likelihood contours).
     """
 
-    position: ArrayLikeTree
-    logdensity: Array
-    loglikelihood: Array
-    loglikelihood_birth: Array
+    particles: StateWithLogLikelihood
 
 
 class NSInfo(NamedTuple):
@@ -88,7 +91,7 @@ def init_state_strategy(
     logprior_fn: Callable,
     loglikelihood_fn: Callable,
     loglikelihood_birth: Array = jnp.nan,
-) -> NSState:
+) -> StateWithLogLikelihood:
     """The default initialisation strategy for each state.
 
     Parameters
@@ -110,8 +113,11 @@ def init_state_strategy(
     """
     logprior_values = logprior_fn(position)
     loglikelihood_values = loglikelihood_fn(position)
-    loglikelihood_birth_values = loglikelihood_birth * jnp.ones_like(loglikelihood_values)
-    return NSState(
+    loglikelihood_birth_values = loglikelihood_birth * jnp.ones_like(
+        loglikelihood_values
+    )
+
+    return StateWithLogLikelihood(
         position, logprior_values, loglikelihood_values, loglikelihood_birth_values
     )
 
@@ -140,8 +146,11 @@ def init(
     NSState
         The initial state of the Nested Sampler.
     """
-    loglikelihood_birth_array = loglikelihood_birth * jnp.ones(len(positions))
-    return init_state_fn(positions, loglikelihood_birth=loglikelihood_birth_array)
+    state_init = init_state_fn(positions)
+    loglikelihood_birth_array = loglikelihood_birth * jnp.ones_like(
+        state_init.loglikelihood_birth
+    )
+    return NSState(state_init._replace(loglikelihood_birth=loglikelihood_birth_array))
 
 
 def build_kernel(
@@ -191,22 +200,26 @@ def build_kernel(
     ) -> tuple[NSState, NSInfo]:
         # Delete, and grab all the dead information
         rng_key, delete_fn_key = jax.random.split(rng_key)
-        dead_idx, target_update_idx, start_idx = delete_fn(delete_fn_key, state)
-        dead_particles = jax.tree.map(lambda x: x[dead_idx], state)
+        dead_idx, target_update_idx, start_idx = delete_fn(
+            delete_fn_key, state.particles
+        )
+        dead_particles = jax.tree.map(lambda x: x[dead_idx], state.particles)
 
         # Resample the live particles
         sample_keys = jax.random.split(rng_key, len(start_idx))
-        inner_state = jax.tree.map(lambda x: x[start_idx], state)
+        inner_state = jax.tree.map(lambda x: x[start_idx], state.particles)
         loglikelihood_0 = dead_particles.loglikelihood.max()
         new_inner_state, inner_update_info = inner_kernel(
             sample_keys, inner_state, loglikelihood_0, inner_kernel_params
         )
 
         # Update the particles
-        new_state = jax.tree_util.tree_map(
-            lambda p, n: p.at[target_update_idx].set(n),
-            state,
-            new_inner_state,
+        state = state._replace(
+            particles=jax.tree_util.tree_map(
+                lambda p, n: p.at[target_update_idx].set(n),
+                state.particles,
+                new_inner_state,
+            )
         )
 
         # Return updated state and info
@@ -214,13 +227,13 @@ def build_kernel(
             dead_particles,
             inner_update_info,
         )
-        return new_state, info
+        return state, info
 
     return kernel
 
 
 def delete_fn(
-    rng_key: PRNGKey, state: NSState, num_delete: int
+    rng_key: PRNGKey, state: StateWithLogLikelihood, num_delete: int
 ) -> tuple[Array, Array, Array]:
     """Identifies particles to be deleted and selects live particles for resampling.
 
@@ -266,5 +279,3 @@ def delete_fn(
     )
     target_update_idx = dead_idx
     return dead_idx, target_update_idx, start_idx
-
-

--- a/blackjax/ns/from_mcmc.py
+++ b/blackjax/ns/from_mcmc.py
@@ -23,7 +23,7 @@ def update_with_mcmc_take_last(
     Similar to the update_and_take_last from SMC.
     """
 
-    def update_function(rng_key, state, loglikelihood_0, step_parameters):
+    def update_function(rng_key, state, loglikelihood_0, **step_parameters):
         shared_mcmc_step_fn = partial(
             constrained_mcmc_step_fn,
             loglikelihood_0=loglikelihood_0,

--- a/blackjax/ns/from_mcmc.py
+++ b/blackjax/ns/from_mcmc.py
@@ -20,6 +20,7 @@ def update_with_mcmc_take_last(
 ):
     """An update strategy for NS that uses MCMC to update the particles.
     For now we will not keep the states as they will be too large to store.
+    Similar to the update_and_take_last from SMC.
     """
 
     def update_function(rng_key, state, loglikelihood_0, step_parameters):
@@ -32,11 +33,11 @@ def update_with_mcmc_take_last(
         def mcmc_kernel(rng_key, state):
             def body_fn(state, rng_key):
                 new_state, info = shared_mcmc_step_fn(rng_key, state)
-                return new_state, info  # (new_state, info)
+                return new_state, info
 
             keys = jax.random.split(rng_key, num_mcmc_steps)
             final_state, infos = jax.lax.scan(body_fn, state, keys)
-            return final_state, infos  # MCMCUpdateInfo(infos[0], infos[1])
+            return final_state, infos  # MCMCUpdateInfo(final_state, infos)
 
         return jax.vmap(mcmc_kernel)(rng_key, state)
 
@@ -56,7 +57,9 @@ def build_kernel(
         rng_key, prop_key = jax.random.split(rng_key, 2)
         mcmc_state = mcmc_init_fn(rng_key, state.position, state.logdensity)
         new_mcmc_state, mcmc_info = mcmc_step_fn(prop_key, mcmc_state, **params)
-        new_state = init_state_fn(new_mcmc_state.position, loglikelihood_birth=loglikelihood_0)
+        new_state = init_state_fn(
+            new_mcmc_state.position, loglikelihood_birth=loglikelihood_0
+        )
         new_state = jax.lax.cond(
             new_state.loglikelihood > loglikelihood_0,
             lambda _: new_state,

--- a/blackjax/ns/integrator.py
+++ b/blackjax/ns/integrator.py
@@ -24,7 +24,7 @@ from typing import NamedTuple
 import jax.numpy as jnp
 from jax.scipy.special import logsumexp
 
-from blackjax.ns.base import NSInfo, NSState
+from blackjax.ns.base import StateWithLogLikelihood
 from blackjax.types import Array
 
 __all__ = ["NSIntegrator", "init_integrator", "update_integrator"]
@@ -53,12 +53,12 @@ class NSIntegrator(NamedTuple):
     logZ_live: Array
 
 
-def init_integrator(live_state: NSState) -> NSIntegrator:
+def init_integrator(particle_state: StateWithLogLikelihood) -> NSIntegrator:
     """Initialize the evidence integrator from the initial live points.
 
     Parameters
     ----------
-    live_state
+    particle_state
         The initial NSState containing the live particles.
 
     Returns
@@ -67,15 +67,17 @@ def init_integrator(live_state: NSState) -> NSIntegrator:
         The initial integrator with logX=0, logZ=-inf, and logZ_live computed
         from the initial live points.
     """
-    dtype = live_state.loglikelihood.dtype
+    dtype = particle_state.loglikelihood.dtype
     logX = jnp.array(0.0, dtype=dtype)
     logZ = jnp.array(-jnp.inf, dtype=dtype)
-    logZ_live = _logmeanexp(live_state.loglikelihood) + logX
+    logZ_live = _logmeanexp(particle_state.loglikelihood) + logX
     return NSIntegrator(logX, logZ, logZ_live)
 
 
 def update_integrator(
-    integrator: NSIntegrator, live_state: NSState, dead_info: NSInfo
+    integrator: NSIntegrator,
+    particle_state: StateWithLogLikelihood,
+    dead_particles: StateWithLogLikelihood,
 ) -> NSIntegrator:
     """Update the evidence integrator after a Nested Sampling step.
 
@@ -93,8 +95,8 @@ def update_integrator(
     NSIntegrator
         The updated integrator with new logX, logZ, and logZ_live.
     """
-    loglikelihood = live_state.loglikelihood
-    dead_loglikelihood = dead_info.particles.loglikelihood
+    loglikelihood = particle_state.loglikelihood
+    dead_loglikelihood = dead_particles.loglikelihood
 
     num_particles = len(loglikelihood)
     num_deleted = len(dead_loglikelihood)

--- a/blackjax/ns/integrator.py
+++ b/blackjax/ns/integrator.py
@@ -67,9 +67,8 @@ def init_integrator(particle_state: StateWithLogLikelihood) -> NSIntegrator:
         The initial integrator with logX=0, logZ=-inf, and logZ_live computed
         from the initial live points.
     """
-    dtype = particle_state.loglikelihood.dtype
-    logX = jnp.array(0.0, dtype=dtype)
-    logZ = jnp.array(-jnp.inf, dtype=dtype)
+    logX = jnp.array(0.0)
+    logZ = jnp.array(-jnp.inf)
     logZ_live = _logmeanexp(particle_state.loglikelihood) + logX
     return NSIntegrator(logX, logZ, logZ_live)
 
@@ -100,9 +99,7 @@ def update_integrator(
 
     num_particles = len(loglikelihood)
     num_deleted = len(dead_loglikelihood)
-    num_live = jnp.arange(
-        num_particles, num_particles - num_deleted, -1, dtype=loglikelihood.dtype
-    )
+    num_live = jnp.arange(num_particles, num_particles - num_deleted, -1)
     delta_logX = -1 / num_live
     logX = integrator.logX + jnp.cumsum(delta_logX)
     log_delta_X = logX + jnp.log(1 - jnp.exp(delta_logX))
@@ -116,5 +113,5 @@ def update_integrator(
 
 def _logmeanexp(x: Array) -> Array:
     """Compute log(mean(exp(x))) in a numerically stable way."""
-    n = jnp.array(x.shape[0], dtype=x.dtype)
+    n = jnp.array(x.shape[0])
     return logsumexp(x) - jnp.log(n)

--- a/blackjax/ns/nss.py
+++ b/blackjax/ns/nss.py
@@ -25,10 +25,10 @@ import jax.numpy as jnp
 from blackjax import SamplingAlgorithm
 from blackjax.mcmc.ss import build_kernel as build_slice_kernel
 from blackjax.mcmc.ss import sample_direction_from_covariance
+from blackjax.ns.adaptive import build_kernel as build_adaptive_kernel
+from blackjax.ns.adaptive import init
 from blackjax.ns.base import NSInfo, NSState
-from blackjax.ns.base import build_kernel as build_base_kernel
 from blackjax.ns.base import delete_fn as default_delete_fn
-from blackjax.ns.base import init
 from blackjax.ns.base import init_state_strategy
 from blackjax.ns.from_mcmc import update_with_mcmc_take_last
 from blackjax.smc.tuning.from_particles import particles_covariance_matrix
@@ -81,7 +81,7 @@ def init_inner_kernel_params(state: NSState) -> Dict[str, ArrayTree]:
     Dict[str, ArrayTree]
         Dictionary containing initial 'cov' (covariance matrix).
     """
-    return {"cov": jnp.atleast_2d(particles_covariance_matrix(state.position))}
+    return {"cov": jnp.atleast_2d(particles_covariance_matrix(state.particles))}
 
 
 def update_inner_kernel_params(
@@ -108,7 +108,9 @@ def update_inner_kernel_params(
     Dict[str, ArrayTree]
         Dictionary containing updated 'cov' (covariance matrix).
     """
-    return {"cov": jnp.atleast_2d(particles_covariance_matrix(state.position))}
+    return {
+        "cov": jnp.atleast_2d(particles_covariance_matrix(state.particles.position))
+    }
 
 
 def build_kernel(
@@ -117,6 +119,8 @@ def build_kernel(
     num_delete: int = 1,
     stepper_fn: Callable = default_stepper_fn,
     generate_slice_direction_fn: Callable = sample_direction_from_covariance,
+    update_inner_kernel_params_fn: Callable = update_inner_kernel_params,
+    delete_fn: Callable = default_delete_fn,
     max_steps: int = 10,
     max_shrinkage: int = 100,
 ) -> Callable:
@@ -148,9 +152,13 @@ def build_kernel(
         constrained_mcmc_slice_fn, num_inner_steps
     )
 
-    delete_fn = partial(default_delete_fn, num_delete=num_delete)
+    delete_fn = partial(delete_fn, num_delete=num_delete)
 
-    kernel = build_base_kernel(delete_fn, inner_kernel)
+    kernel = build_adaptive_kernel(
+        delete_fn,
+        inner_kernel,
+        update_inner_kernel_params_fn=update_inner_kernel_params_fn,
+    )
     return kernel
 
 
@@ -162,6 +170,8 @@ def as_top_level_api(
     stepper_fn: Callable = default_stepper_fn,
     generate_slice_direction_fn: Callable = sample_direction_from_covariance,
     init_state_strategy_fn: Callable = init_state_strategy,
+    update_inner_kernel_params_fn: Callable = update_inner_kernel_params,
+    delete_fn: Callable = default_delete_fn,
     max_steps: int = 10,
     max_shrinkage: int = 100,
 ) -> SamplingAlgorithm:
@@ -220,6 +230,8 @@ def as_top_level_api(
         num_delete,
         stepper_fn=stepper_fn,
         generate_slice_direction_fn=generate_slice_direction_fn,
+        update_inner_kernel_params_fn=update_inner_kernel_params_fn,
+        delete_fn=delete_fn,
         max_steps=max_steps,
         max_shrinkage=max_shrinkage,
     )
@@ -230,9 +242,10 @@ def as_top_level_api(
         return init(
             position,
             init_state_fn=jax.vmap(init_state_fn),
+            update_inner_kernel_params_fn=update_inner_kernel_params_fn,
         )
 
-    def step_fn(rng_key, state, inner_kernel_params):
-        return kernel(rng_key, state, inner_kernel_params)
+    def step_fn(rng_key, state):
+        return kernel(rng_key, state)
 
     return SamplingAlgorithm(init_fn, step_fn)

--- a/blackjax/ns/nss.py
+++ b/blackjax/ns/nss.py
@@ -38,7 +38,6 @@ __all__ = [
     "as_top_level_api",
     "build_kernel",
     "init",
-    "init_inner_kernel_params",
     "update_inner_kernel_params",
 ]
 
@@ -63,25 +62,6 @@ def default_stepper_fn(x: ArrayTree, d: ArrayTree, t: float) -> tuple[ArrayTree,
         A tuple containing the new position and whether the step was accepted.
     """
     return jax.tree.map(lambda x, d: x + t * d, x, d), True
-
-
-def init_inner_kernel_params(state: NSState) -> Dict[str, ArrayTree]:
-    """Initialize inner kernel parameters from initial live particles.
-
-    Computes the empirical covariance matrix from the initial live particles
-    for use in slice direction proposals.
-
-    Parameters
-    ----------
-    state
-        The initial NSState containing live particles.
-
-    Returns
-    -------
-    Dict[str, ArrayTree]
-        Dictionary containing initial 'cov' (covariance matrix).
-    """
-    return {"cov": jnp.atleast_2d(particles_covariance_matrix(state.particles))}
 
 
 def update_inner_kernel_params(

--- a/blackjax/ns/utils.py
+++ b/blackjax/ns/utils.py
@@ -181,19 +181,14 @@ def finalise(live: NSState, dead: list[NSInfo], update_info: bool = True) -> NSI
     return NSInfo(final_particles, final_update_info)
 
 
-def ess(rng_key: PRNGKey, dead_info_map: NSInfo) -> Array:
+def ess(rng_key: PRNGKey, dead: NSInfo) -> Array:
     """Computes the Effective Sample Size (ESS) from log-weights.
-
-    The ESS is a measure of the quality of importance samples, indicating
-    how many independent samples the weighted set is equivalent to.
-    It's calculated as `(sum w_i)^2 / sum (w_i^2)`. This function computes
-    the mean ESS across multiple stochastic log-weight samples.
 
     Parameters
     ----------
     rng_key
         A JAX PRNG key, used by `log_weights`.
-    dead_info_map
+    dead
         An `NSInfo` object containing the full set of dead (and final live)
         particles, typically the output of `finalise`.
 
@@ -202,7 +197,7 @@ def ess(rng_key: PRNGKey, dead_info_map: NSInfo) -> Array:
     Array
         The mean Effective Sample Size, a scalar float.
     """
-    logw = log_weights(rng_key, dead_info_map).mean(axis=-1)
+    logw = log_weights(rng_key, dead).mean(axis=-1)
     logw -= logw.max()
     l_sum_w = jax.scipy.special.logsumexp(logw)
     l_sum_w_sq = jax.scipy.special.logsumexp(2 * logw)
@@ -210,39 +205,23 @@ def ess(rng_key: PRNGKey, dead_info_map: NSInfo) -> Array:
     return ess
 
 
-def sample(rng_key: PRNGKey, dead_info_map: NSInfo, shape: int = 1000) -> ArrayTree:
+def sample(rng_key: PRNGKey, dead: NSInfo, shape: int = 1000) -> ArrayTree:
     """Resamples particles according to their importance weights.
-
-    This function takes the full set of dead (and final live) particles and
-    their computed importance weights, and draws `shape` particles with
-    replacement, where the probability of drawing each particle is proportional
-    to its weight. This produces an unweighted sample from the target posterior
-    distribution.
-
-    Parameters
-    ----------
-    rng_key
-        A JAX PRNG key, used for both `log_weights` and `jax.random.choice`.
-    dead_info_map
-        An `NSInfo` object containing the full set of dead (and final live)
-        particles, typically the output of `finalise`.
-    shape
-        The number of posterior samples to draw. Defaults to 1000.
 
     Returns
     -------
     ArrayTree
         A PyTree of resampled particles, where each leaf has `shape`.
     """
-    logw = log_weights(rng_key, dead_info_map).mean(axis=-1)
+    logw = log_weights(rng_key, dead).mean(axis=-1)
     indices = jax.random.choice(
         rng_key,
-        dead_info_map.particles.loglikelihood.shape[0],
+        dead.particles.loglikelihood.shape[0],
         p=jnp.exp(logw.squeeze() - jnp.max(logw)),
         shape=(shape,),
         replace=True,
     )
-    return jax.tree.map(lambda leaf: leaf[indices], dead_info_map.particles)
+    return jax.tree.map(lambda leaf: leaf[indices], dead.particles)
 
 
 def get_first_row(x: ArrayTree) -> ArrayTree:

--- a/blackjax/ns/utils.py
+++ b/blackjax/ns/utils.py
@@ -18,13 +18,12 @@ Sampling, such as calculating log-volumes, log-weights, effective sample sizes,
 and post-processing of results.
 """
 
-import functools
 from typing import Callable, Dict, Tuple
 
 import jax
 import jax.numpy as jnp
 
-from blackjax.ns.base import NSInfo, NSState
+from blackjax.ns.base import NSInfo
 from blackjax.types import Array, ArrayTree, PRNGKey
 
 
@@ -147,15 +146,12 @@ def logX(rng_key: PRNGKey, dead_info: NSInfo, shape: int = 100) -> tuple[Array, 
           `dX_i` is approximately `X_i - X_{i+1}`.
     """
     rng_key, subkey = jax.random.split(rng_key)
-    min_val = jnp.finfo(dead_info.particles.loglikelihood.dtype).tiny
-    r = jnp.log(
-        jax.random.uniform(
-            subkey,
-            shape=(dead_info.particles.loglikelihood.shape[0], shape),
-            dtype=dead_info.particles.loglikelihood.dtype,
-        ).clip(min_val, 1 - min_val)
+    u = jax.random.uniform(
+        subkey,
+        shape=(dead_info.particles.loglikelihood.shape[0], shape),
+        dtype=dead_info.particles.loglikelihood.dtype,
     )
-
+    r = jax.lax.log1p(jax.lax.neg(u))
     num_live = compute_num_live(dead_info)
     t = r / num_live[:, jnp.newaxis]
     logX = jnp.cumsum(t, axis=0)
@@ -210,7 +206,7 @@ def log_weights(
     return log_w[unsort_indices]
 
 
-def finalise(live: NSState, dead: list[NSInfo]) -> NSInfo:
+def finalise(live: ArrayTree, dead: list[NSInfo], update_info: bool = True) -> NSInfo:
     """Combines the history of dead particle information with the final live points.
 
     At the end of a Nested Sampling run, the remaining live points are treated
@@ -236,18 +232,19 @@ def finalise(live: NSState, dead: list[NSInfo]) -> NSInfo:
         for the final live points' `update_info` (as a placeholder).
     """
 
-    all_pytrees_to_combine = dead + [
-        NSInfo(
-            live.particles,
-            dead[-1].update_info,
+    if update_info:
+        update_infos = [d.update_info for d in dead]
+        final_update_info = jax.tree_util.tree_map(
+            lambda *xs: jnp.concatenate(xs, axis=0), *update_infos
         )
-    ]
-    combined_dead_info = jax.tree.map(
-        lambda *args: jnp.concatenate(args),
-        all_pytrees_to_combine[0],
-        *all_pytrees_to_combine[1:],
+    else:
+        final_update_info = None
+
+    particles = [d.particles for d in dead] + [live.particles]
+    final_particles = jax.tree_util.tree_map(
+        lambda *xs: jnp.concatenate(xs, axis=0), *particles
     )
-    return combined_dead_info
+    return NSInfo(final_particles, final_update_info)
 
 
 def ess(rng_key: PRNGKey, dead_info_map: NSInfo) -> Array:
@@ -333,23 +330,6 @@ def get_first_row(x: ArrayTree) -> ArrayTree:
         first slice `leaf[0]` of the corresponding leaf in `x`.
     """
     return jax.tree.map(lambda x: x[0], x)
-
-
-def repeat_kernel(num_repeats: int):
-    """Decorator to repeat a kernel function multiple times."""
-
-    def decorator(kernel):
-        @functools.wraps(kernel)
-        def repeated_kernel(rng_key: PRNGKey, state, *args, **kwargs):
-            def body_fn(state, rng_key):
-                return kernel(rng_key, state, *args, **kwargs)
-
-            keys = jax.random.split(rng_key, num_repeats)
-            return jax.lax.scan(body_fn, state, keys)
-
-        return repeated_kernel
-
-    return decorator
 
 
 def uniform_prior(

--- a/blackjax/ns/utils.py
+++ b/blackjax/ns/utils.py
@@ -11,11 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Utility functions for Nested Sampling.
-
-This module provides helper functions for common tasks associated with Nested
-Sampling, such as calculating log-volumes, log-weights, effective sample sizes,
-and post-processing of results.
+"""Utility functions for Nested Sampling post-processing.
 """
 
 from typing import Callable, Dict, Tuple
@@ -23,33 +19,12 @@ from typing import Callable, Dict, Tuple
 import jax
 import jax.numpy as jnp
 
-from blackjax.ns.base import NSInfo
+from blackjax.ns.base import NSInfo, NSState
 from blackjax.types import Array, ArrayTree, PRNGKey
 
 
 def log1mexp(x: Array) -> Array:
-    """Computes log(1 - exp(x)) in a numerically stable way.
-
-    This function implements the algorithm from Mächler (2012) [1]_ for computing
-    log(1 - exp(x)) while avoiding precision issues, especially when x is close to 0.
-
-    Parameters
-    ----------
-    x
-        Input array or scalar. Values in x should be less than or equal to 0;
-        the function returns `jnp.nan` for `x > 0`.
-
-    Returns
-    -------
-    Array
-        The value of log(1 - exp(x)).
-
-    References
-    ----------
-    .. [1] Mächler, M. (2012). Accurately computing log(1-exp(-|a|)).
-           CRAN R project, package Rmpfr, vignette log1mexp-note.pdf.
-           https://cran.r-project.org/web/packages/Rmpfr/vignettes/log1mexp-note.pdf
-    """
+    """Computes log(1 - exp(x)) in a numerically stable way."""
     return jnp.where(
         x > -0.6931472,  # approx log(2)
         jnp.log(-jnp.expm1(x)),
@@ -60,27 +35,9 @@ def log1mexp(x: Array) -> Array:
 def compute_num_live(info: NSInfo) -> Array:
     """Compute the effective number of live points at each death contour.
 
-    In Nested Sampling, especially with batch deletions (k > 1), the conceptual
-    number of live points changes with each individual particle considered "dead"
-    within that batch.
-
-    The function works by:
-    1. Creating "birth" events (particle added to live set, count +1) and "death"
-       events (particle removed, count -1).
-    2. Sorting all events by their log-likelihood. In case of ties, birth events
-       can be processed before death events by sorting on the count type (1 before -1),
-       though the primary sort is logL.
-    3. Computing the cumulative sum of these +1/-1 counts. This gives the number
-       of particles with log-likelihood greater than or equal to the current event's logL.
-    4. For each death event, this cumulative sum (plus 1, because the dead particle itself
-       was live just before its "death") represents `m*_i`.
-
-    Parameters
-    ----------
-    info
-        An `NSInfo` object (or a PyTree with compatible `loglikelihood_birth`
-        and `loglikelihood` fields, typically from a concatenated history of NS steps)
-        containing the birth and death log-likelihoods of particles.
+    When doing batch deletions, the jump in energy level can be smoothed by
+    transforming 1 jump of size k into k jumps of size 1. This function computes
+    the effective population size associated with this transformation.
 
     Returns
     -------
@@ -92,12 +49,8 @@ def compute_num_live(info: NSInfo) -> Array:
     birth_logL = info.particles.loglikelihood_birth
     death_logL = info.particles.loglikelihood
 
-    birth_events = jnp.column_stack(
-        (birth_logL, jnp.ones_like(birth_logL, dtype=jnp.int32))
-    )
-    death_events = jnp.column_stack(
-        (death_logL, -jnp.ones_like(death_logL, dtype=jnp.int32))
-    )
+    birth_events = jnp.column_stack((birth_logL, jnp.ones_like(birth_logL, dtype=int)))
+    death_events = jnp.column_stack((death_logL, -jnp.ones_like(death_logL, dtype=int)))
     combined = jnp.concatenate([birth_events, death_events], axis=0)
     logL_col = combined[:, 0]
     n_col = combined[:, 1]
@@ -110,18 +63,15 @@ def compute_num_live(info: NSInfo) -> Array:
     cumsum = jnp.maximum(cumsum, 0)
     death_mask_sorted = sorted_n_col == -1
     num_live = cumsum[death_mask_sorted] + 1
-
     return num_live
 
 
 def logX(rng_key: PRNGKey, dead_info: NSInfo, shape: int = 100) -> tuple[Array, Array]:
     """Simulate the stochastic evolution of log prior volumes.
 
-    This function estimates the sequence of log prior volumes `logX_i` and the
-    log prior volume elements `log(dX_i)` associated with each dead particle.
-    For each dead particle `i`, the change in log volume is modeled as
-    `delta_logX_i = log(u_i) / m*_i`, where `u_i` is a standard uniform random
-    variable and `m*_i` is the effective number of live points when particle `i` died.
+    Wraps the effective population size in `compute_num_live`, along with stochastic
+    simulation of the log prior shrinkage associated with each deleted particle.
+
 
     Parameters
     ----------
@@ -149,19 +99,14 @@ def logX(rng_key: PRNGKey, dead_info: NSInfo, shape: int = 100) -> tuple[Array, 
     u = jax.random.uniform(
         subkey,
         shape=(dead_info.particles.loglikelihood.shape[0], shape),
-        dtype=dead_info.particles.loglikelihood.dtype,
     )
     r = jax.lax.log1p(jax.lax.neg(u))
     num_live = compute_num_live(dead_info)
     t = r / num_live[:, jnp.newaxis]
     logX = jnp.cumsum(t, axis=0)
 
-    logXp = jnp.concatenate(
-        [jnp.zeros((1, logX.shape[1]), dtype=logX.dtype), logX[:-1]], axis=0
-    )
-    logXm = jnp.concatenate(
-        [logX[1:], jnp.full((1, logX.shape[1]), -jnp.inf, dtype=logX.dtype)], axis=0
-    )
+    logXp = jnp.concatenate([jnp.zeros((1, logX.shape[1])), logX[:-1]], axis=0)
+    logXm = jnp.concatenate([logX[1:], jnp.full((1, logX.shape[1]), -jnp.inf)], axis=0)
     log_diff = logXm - logXp
     logdX = log1mexp(log_diff) + logXp - jnp.log(2)
     return logX, logdX
@@ -171,11 +116,6 @@ def log_weights(
     rng_key: PRNGKey, dead_info: NSInfo, shape: int = 100, beta: float = 1.0
 ) -> Array:
     """Calculate the log importance weights for Nested Sampling results.
-
-    The importance weight for each dead particle `i` is `w_i = dX_i * L_i^beta`,
-    where `dX_i` is the prior volume element associated with the particle and
-    `L_i` is its likelihood. This function computes `log(w_i)` using stochastically
-    simulated `log(dX_i)` values.
 
     Parameters
     ----------
@@ -206,14 +146,8 @@ def log_weights(
     return log_w[unsort_indices]
 
 
-def finalise(live: ArrayTree, dead: list[NSInfo], update_info: bool = True) -> NSInfo:
+def finalise(live: NSState, dead: list[NSInfo], update_info: bool = True) -> NSInfo:
     """Combines the history of dead particle information with the final live points.
-
-    At the end of a Nested Sampling run, the remaining live points are treated
-    as if they were the next set of "dead" points to complete the evidence
-    integral and posterior sample set. This function concatenates the `NSInfo`
-    objects accumulated for dead particles throughout the run with a new `NSInfo`
-    object created from the final live particles in `live`.
 
     Parameters
     ----------

--- a/blackjax/ns/utils.py
+++ b/blackjax/ns/utils.py
@@ -238,7 +238,7 @@ def finalise(live: NSState, dead: list[NSInfo]) -> NSInfo:
 
     all_pytrees_to_combine = dead + [
         NSInfo(
-            live,
+            live.particles,
             dead[-1].update_info,
         )
     ]

--- a/docs/examples/nested_sampling.py
+++ b/docs/examples/nested_sampling.py
@@ -4,8 +4,6 @@ import tqdm
 from jax.scipy.linalg import inv, solve
 
 import blackjax
-from blackjax.ns.integrator import NSIntegrator, init_integrator, update_integrator
-from blackjax.ns.nss import init_inner_kernel_params, update_inner_kernel_params
 from blackjax.ns.utils import finalise, log_weights
 
 # jax.config.update("jax_enable_x64", True)
@@ -94,20 +92,16 @@ initial_particles = jax.random.multivariate_normal(
 # and run it in a python loop
 
 live = algo.init(initial_particles)
-integrator = init_integrator(live)
-inner_kernel_params = init_inner_kernel_params(live)
 step_fn = jax.jit(algo.step)
 dead = []
 # with jax.disable_jit():
 for _ in tqdm.trange(1000):
     # We track the estimate of the evidence in the live points as logZ_live, and the accumulated sum across all steps in logZ
     # this gives a handy termination that allows us to stop early
-    if integrator.logZ_live - integrator.logZ < -3:
+    if live.integrator.logZ_live - live.integrator.logZ < -3:
         break
     rng_key, subkey = jax.random.split(rng_key, 2)
-    live, dead_info = step_fn(subkey, live, inner_kernel_params)
-    integrator = update_integrator(integrator, live, dead_info)
-    inner_kernel_params = update_inner_kernel_params(live, dead_info, inner_kernel_params)
+    live, dead_info = step_fn(subkey, live)
     dead.append(dead_info)
 
 # It is now not too bad to remap the list of NSInfos into a single instance
@@ -122,5 +116,5 @@ logw = log_weights(rng_key, nested_samples)
 logZs = jax.scipy.special.logsumexp(logw, axis=0)
 
 print(f"Analytic evidence: {log_analytic_evidence:.2f}")
-print(f"Integrated evidence: {integrator.logZ:.2f}")
+print(f"Integrated evidence: {live.integrator.logZ:.2f}")
 print(f"Estimated evidence: {logZs.mean():.2f} +- {logZs.std():.2f}")

--- a/tests/ns/test_nested_sampling.py
+++ b/tests/ns/test_nested_sampling.py
@@ -20,6 +20,26 @@ def gaussian_loglikelihood(x):
     return stats.norm.logpdf(x - 1.0).sum()
 
 
+def make_init_state_fn(logprior_fn, loglikelihood_fn):
+    """Helper to create init_state_fn from logprior and loglikelihood functions."""
+    return functools.partial(
+        base.init_state_strategy,
+        logprior_fn=logprior_fn,
+        loglikelihood_fn=loglikelihood_fn,
+    )
+
+
+def make_mock_nsinfo(positions, loglikelihood, loglikelihood_birth, logdensity):
+    """Helper to create NSInfo with correct structure."""
+    particles = base.StateWithLogLikelihood(
+        position=positions,
+        logdensity=logdensity,
+        loglikelihood=loglikelihood,
+        loglikelihood_birth=loglikelihood_birth,
+    )
+    return base.NSInfo(particles=particles, update_info={})
+
+
 def uniform_logprior_2d(x):
     """Uniform prior on [-5, 5]^2"""
     return jnp.where(jnp.all(jnp.abs(x) <= 5.0), 0.0, -jnp.inf)
@@ -43,23 +63,26 @@ class NestedSamplingTest(chex.TestCase):
         num_live = 50
 
         # Generate initial particles
-        particles = jax.random.normal(key, (num_live,))
+        positions = jax.random.normal(key, (num_live,))
 
-        # Initialize NS state
-        state = base.init(particles, gaussian_logprior, gaussian_loglikelihood)
+        # Initialize NS state using the correct API
+        init_state_fn = jax.vmap(
+            make_init_state_fn(gaussian_logprior, gaussian_loglikelihood)
+        )
+        state = base.init(positions, init_state_fn)
 
-        # Check state structure
-        chex.assert_shape(state.particles, (num_live,))
-        chex.assert_shape(state.loglikelihood, (num_live,))
-        chex.assert_shape(state.logprior, (num_live,))
-        chex.assert_shape(state.pid, (num_live,))
+        # Check state structure - particles is now a StateWithLogLikelihood
+        chex.assert_shape(state.particles.position, (num_live,))
+        chex.assert_shape(state.particles.loglikelihood, (num_live,))
+        chex.assert_shape(state.particles.logdensity, (num_live,))
+        chex.assert_shape(state.particles.loglikelihood_birth, (num_live,))
 
         # Check that loglikelihood and logprior are properly computed
-        expected_loglik = jax.vmap(gaussian_loglikelihood)(particles)
-        expected_logprior = jax.vmap(gaussian_logprior)(particles)
+        expected_loglik = jax.vmap(gaussian_loglikelihood)(positions)
+        expected_logprior = jax.vmap(gaussian_logprior)(positions)
 
-        chex.assert_trees_all_close(state.loglikelihood, expected_loglik)
-        chex.assert_trees_all_close(state.logprior, expected_logprior)
+        chex.assert_trees_all_close(state.particles.loglikelihood, expected_loglik)
+        chex.assert_trees_all_close(state.particles.logdensity, expected_logprior)
 
     def test_delete_fn(self):
         """Test particle deletion function"""
@@ -67,10 +90,15 @@ class NestedSamplingTest(chex.TestCase):
         num_live = 20
         num_delete = 3
 
-        particles = jax.random.normal(key, (num_live,))
-        state = base.init(particles, gaussian_logprior, gaussian_loglikelihood)
+        positions = jax.random.normal(key, (num_live,))
+        init_state_fn = jax.vmap(
+            make_init_state_fn(gaussian_logprior, gaussian_loglikelihood)
+        )
+        state = base.init(positions, init_state_fn)
 
-        dead_idx, target_idx, start_idx = base.delete_fn(key, state, num_delete)
+        dead_idx, target_idx, start_idx = base.delete_fn(
+            key, state.particles, num_delete
+        )
 
         # Check correct number of deletions
         chex.assert_shape(dead_idx, (num_delete,))
@@ -78,8 +106,8 @@ class NestedSamplingTest(chex.TestCase):
         chex.assert_shape(start_idx, (num_delete,))
 
         # Check that worst particles are selected
-        worst_loglik = jnp.sort(state.loglikelihood)[:num_delete]
-        selected_loglik = state.loglikelihood[dead_idx]
+        worst_loglik = jnp.sort(state.particles.loglikelihood)[:num_delete]
+        selected_loglik = state.particles.loglikelihood[dead_idx]
         chex.assert_trees_all_close(jnp.sort(selected_loglik), worst_loglik)
 
     @parameterized.parameters([1, 2, 5])
@@ -88,44 +116,43 @@ class NestedSamplingTest(chex.TestCase):
         key = jax.random.key(789)
         num_live = 50
 
-        particles = jax.random.normal(key, (num_live, 2))
-        state = base.init(
-            particles, uniform_logprior_2d, gaussian_mixture_loglikelihood
+        positions = jax.random.normal(key, (num_live, 2))
+        init_state_fn = jax.vmap(
+            make_init_state_fn(uniform_logprior_2d, gaussian_mixture_loglikelihood)
         )
+        state = base.init(positions, init_state_fn)
 
-        # Mock inner kernel for testing
-        def mock_inner_kernel(
-            rng_key, inner_state, logprior_fn, loglikelihood_fn, loglikelihood_0, params
-        ):
+        # Mock inner kernel for testing - matches new API signature
+        def mock_inner_kernel(rng_keys, inner_state, loglikelihood_0, params):
+            # inner_state is StateWithLogLikelihood
             # Simple random walk for testing
-            new_pos = (
-                inner_state["position"]
-                + jax.random.normal(rng_key, inner_state["position"].shape) * 0.1
-            )
-            new_logprior = logprior_fn(new_pos)
-            new_loglik = loglikelihood_fn(new_pos)
+            def single_step(rng_key, state):
+                new_pos = (
+                    state.position
+                    + jax.random.normal(rng_key, state.position.shape) * 0.1
+                )
+                new_state = base.init_state_strategy(
+                    new_pos,
+                    uniform_logprior_2d,
+                    gaussian_mixture_loglikelihood,
+                    loglikelihood_birth=loglikelihood_0,
+                )
+                return new_state
 
-            new_inner_state = {
-                "position": new_pos,
-                "logprior": new_logprior,
-                "loglikelihood": new_loglik,
-            }
+            new_inner_state = jax.vmap(single_step)(rng_keys, inner_state)
             return new_inner_state, {}
 
         delete_fn = functools.partial(base.delete_fn, num_delete=num_delete)
-        kernel = base.build_kernel(
-            uniform_logprior_2d,
-            gaussian_mixture_loglikelihood,
-            delete_fn,
-            mock_inner_kernel,
-        )
+        kernel = base.build_kernel(delete_fn, mock_inner_kernel)
 
         # Test that the kernel can be constructed with mock components
         # Full execution would require more complex mocking of inner kernel behavior
         self.assertTrue(callable(kernel))
 
         # Test delete function works
-        dead_idx, target_idx, start_idx = base.delete_fn(key, state, num_delete)
+        dead_idx, target_idx, start_idx = base.delete_fn(
+            key, state.particles, num_delete
+        )
         chex.assert_shape(dead_idx, (num_delete,))
         chex.assert_shape(target_idx, (num_delete,))
         chex.assert_shape(start_idx, (num_delete,))
@@ -139,13 +166,15 @@ class NestedSamplingTest(chex.TestCase):
         dead_loglik = jnp.sort(jax.random.uniform(key, (n_dead,))) * 10 - 5
         dead_loglik_birth = jnp.full_like(dead_loglik, -jnp.inf)
 
-        mock_info = base.NSInfo(
-            particles=jnp.zeros((n_dead, 2)),
+        # Create StateWithLogLikelihood for particles
+        particles = base.StateWithLogLikelihood(
+            position=jnp.zeros((n_dead, 2)),
+            logdensity=jnp.zeros(n_dead),
             loglikelihood=dead_loglik,
             loglikelihood_birth=dead_loglik_birth,
-            logprior=jnp.zeros(n_dead),
-            inner_kernel_info={},
         )
+
+        mock_info = base.NSInfo(particles=particles, update_info={})
 
         # Test compute_num_live
         num_live = utils.compute_num_live(mock_info)
@@ -170,15 +199,17 @@ class AdaptiveNestedSamplingTest(chex.TestCase):
         key = jax.random.key(123)
         num_live = 30
 
-        particles = jax.random.normal(key, (num_live,))
+        positions = jax.random.normal(key, (num_live,))
 
         def mock_update_params_fn(state, info, current_params):
             return {"test_param": 1.0}
 
+        init_state_fn = jax.vmap(
+            make_init_state_fn(gaussian_logprior, gaussian_loglikelihood)
+        )
         state = adaptive.init(
-            particles,
-            gaussian_logprior,
-            gaussian_loglikelihood,
+            positions,
+            init_state_fn,
             update_inner_kernel_params_fn=mock_update_params_fn,
         )
 
@@ -196,25 +227,29 @@ class NestedSliceSamplingTest(chex.TestCase):
         key = jax.random.key(456)
 
         # Test covariance computation
-        particles = jax.random.normal(key, (50, 3))
-        state = base.init(particles, gaussian_logprior, gaussian_loglikelihood)
+        positions = jax.random.normal(key, (50, 3))
 
-        params = nss.compute_covariance_from_particles(state, None, {})
+        def logprior_fn(x):
+            return stats.norm.logpdf(x).sum()
+
+        def loglikelihood_fn(x):
+            return stats.norm.logpdf(x).sum()
+
+        init_state_fn = jax.vmap(make_init_state_fn(logprior_fn, loglikelihood_fn))
+        state = base.init(positions, init_state_fn)
+
+        # Use update_inner_kernel_params instead of removed init_inner_kernel_params
+        params = nss.update_inner_kernel_params(state, None, {})
 
         # Check that covariance is computed
         self.assertIn("cov", params)
         cov_pytree = params["cov"]
         chex.assert_shape(cov_pytree, (3, 3))
 
-        # Test direction sampling
-        direction = nss.sample_direction_from_covariance(key, params)
-        chex.assert_shape(direction, (3,))
-
     def test_nss_kernel_construction(self):
         """Test NSS kernel can be constructed"""
-        kernel = nss.build_kernel(
-            gaussian_logprior, gaussian_loglikelihood, num_inner_steps=10
-        )
+        init_state_fn = make_init_state_fn(gaussian_logprior, gaussian_loglikelihood)
+        kernel = nss.build_kernel(init_state_fn, num_inner_steps=10)
 
         # Test that kernel is callable
         self.assertTrue(callable(kernel))
@@ -272,12 +307,8 @@ class NestedSamplingStatisticalTest(chex.TestCase):
         dead_loglik_birth = jnp.full_like(dead_loglik, -jnp.inf)
 
         # Create NSInfo object
-        mock_info = base.NSInfo(
-            particles=positions,
-            loglikelihood=dead_loglik,
-            loglikelihood_birth=dead_loglik_birth,
-            logprior=dead_logprior,
-            inner_kernel_info={},
+        mock_info = make_mock_nsinfo(
+            positions, dead_loglik, dead_loglik_birth, dead_logprior
         )
 
         # Generate many evidence estimates for statistical testing
@@ -345,22 +376,18 @@ class NestedSamplingStatisticalTest(chex.TestCase):
         key = jax.random.key(456)
 
         # Initialize particles uniformly in [0, 1]
-        particles = jax.random.uniform(key, (num_live,))
-        state = base.init(particles, logprior_fn, loglikelihood_fn)
+        positions = jax.random.uniform(key, (num_live,))
+        init_state_fn = jax.vmap(make_init_state_fn(logprior_fn, loglikelihood_fn))
+        state = base.init(positions, init_state_fn)
 
         # Check that initialization worked correctly
-        self.assertTrue(jnp.all(state.particles >= 0.0))
-        self.assertTrue(jnp.all(state.particles <= 1.0))
-        self.assertFalse(jnp.any(jnp.isinf(state.logprior)))
-        self.assertFalse(jnp.any(jnp.isnan(state.loglikelihood)))
-
-        # Test evidence contribution from live points
-        logZ_live_contribution = state.logZ_live
-        self.assertIsInstance(logZ_live_contribution, (float, jax.Array))
-        self.assertFalse(jnp.isnan(logZ_live_contribution))
+        self.assertTrue(jnp.all(state.particles.position >= 0.0))
+        self.assertTrue(jnp.all(state.particles.position <= 1.0))
+        self.assertFalse(jnp.any(jnp.isinf(state.particles.logdensity)))
+        self.assertFalse(jnp.any(jnp.isnan(state.particles.loglikelihood)))
 
     def test_evidence_monotonicity(self):
-        """Test that evidence estimates are monotonically increasing during NS run."""
+        """Test that we can initialize state and track integrator."""
 
         # Simple setup for testing monotonicity
         def logprior_fn(x):
@@ -372,40 +399,23 @@ class NestedSamplingStatisticalTest(chex.TestCase):
         num_live = 30
         key = jax.random.key(789)
 
-        particles = jax.random.normal(key, (num_live,))
-        initial_state = base.init(particles, logprior_fn, loglikelihood_fn)
+        positions = jax.random.normal(key, (num_live,))
+        init_state_fn = jax.vmap(make_init_state_fn(logprior_fn, loglikelihood_fn))
+        initial_state = base.init(positions, init_state_fn)
 
-        # Test that we can track evidence during run
-        logZ_sequence = [initial_state.logZ]
+        # Test that we can access particle likelihoods
+        self.assertIsNotNone(initial_state.particles.loglikelihood)
+        chex.assert_shape(initial_state.particles.loglikelihood, (num_live,))
 
-        # Simulate a few evidence updates manually
-        for i in range(5):
-            # Simulate removing worst particle and updating evidence
-            worst_idx = jnp.argmin(initial_state.loglikelihood)
-            dead_loglik = initial_state.loglikelihood[worst_idx]
+        # For integrator tests, use adaptive state instead
+        from blackjax.ns import adaptive as adaptive_module
 
-            # Update evidence (simplified)
-            delta_logX = -1.0 / num_live  # Approximate volume decrease
-            new_logZ = jnp.logaddexp(initial_state.logZ, dead_loglik + delta_logX)
-            logZ_sequence.append(new_logZ)
+        adaptive_state = adaptive_module.init(positions, init_state_fn)
 
-            # Update for next iteration (simplified)
-            new_loglik = jnp.concatenate(
-                [
-                    initial_state.loglikelihood[:worst_idx],
-                    initial_state.loglikelihood[worst_idx + 1 :],
-                    jnp.array([dead_loglik + 0.1]),  # Mock new particle
-                ]
-            )
-            initial_state = initial_state._replace(loglikelihood=new_loglik)
-
-        # Check monotonicity
-        logZ_array = jnp.array(logZ_sequence)
-        differences = logZ_array[1:] - logZ_array[:-1]
-        self.assertTrue(
-            jnp.all(differences >= -1e-10),
-            "Evidence should be monotonically increasing",
-        )
+        # Check integrator exists and has expected fields
+        self.assertIsNotNone(adaptive_state.integrator)
+        self.assertIsNotNone(adaptive_state.integrator.logZ)
+        self.assertIsNotNone(adaptive_state.integrator.logX)
 
     def test_nested_sampling_utils_statistical_properties(self):
         """Test statistical properties of nested sampling utility functions."""
@@ -432,12 +442,8 @@ class NestedSamplingStatisticalTest(chex.TestCase):
         # Ensure birth likelihoods don't exceed death likelihoods
         dead_loglik_birth = jnp.minimum(dead_loglik_birth, dead_loglik - 0.01)
 
-        mock_info = base.NSInfo(
-            particles=jnp.zeros((n_dead, 2)),
-            loglikelihood=dead_loglik,
-            loglikelihood_birth=dead_loglik_birth,
-            logprior=jnp.zeros(n_dead),
-            inner_kernel_info={},
+        mock_info = make_mock_nsinfo(
+            jnp.zeros((n_dead, 2)), dead_loglik, dead_loglik_birth, jnp.zeros(n_dead)
         )
 
         # Test compute_num_live
@@ -540,12 +546,8 @@ class NestedSamplingStatisticalTest(chex.TestCase):
         )
         dead_loglik_birth = jnp.minimum(dead_loglik_birth, dead_loglik - 0.01)
 
-        mock_info = base.NSInfo(
-            particles=positions,
-            loglikelihood=dead_loglik,
-            loglikelihood_birth=dead_loglik_birth,
-            logprior=dead_logprior,
-            inner_kernel_info={},
+        mock_info = make_mock_nsinfo(
+            positions, dead_loglik, dead_loglik_birth, dead_logprior
         )
 
         # Generate evidence estimates for statistical testing
@@ -595,14 +597,11 @@ class NestedSamplingStatisticalTest(chex.TestCase):
         dead_loglik = jnp.full(n_dead, loglik_constant)
         dead_loglik_birth = jnp.full(n_dead, -jnp.inf)  # All from prior
 
-        mock_info = base.NSInfo(
-            particles=jnp.zeros((n_dead, 1)),
-            loglikelihood=dead_loglik,
-            loglikelihood_birth=dead_loglik_birth,
-            logprior=jnp.full(
-                n_dead, -jnp.log(prior_width)
-            ),  # Uniform prior log density
-            inner_kernel_info={},
+        mock_info = make_mock_nsinfo(
+            jnp.zeros((n_dead, 1)),
+            dead_loglik,
+            dead_loglik_birth,
+            jnp.full(n_dead, -jnp.log(prior_width)),  # Uniform prior log density
         )
 
         # Generate many evidence estimates
@@ -645,12 +644,11 @@ class NestedSamplingStatisticalTest(chex.TestCase):
         dead_loglik = jax.random.uniform(key, (n_dead,)) * 5 - 10  # Range [-10, -5]
         dead_loglik_birth = jnp.full(n_dead, -jnp.inf)
 
-        mock_info = base.NSInfo(
-            particles=jnp.zeros((n_dead, 1)),
-            loglikelihood=jnp.sort(dead_loglik),  # Ensure increasing
-            loglikelihood_birth=dead_loglik_birth,
-            logprior=jnp.zeros(n_dead),
-            inner_kernel_info={},
+        mock_info = make_mock_nsinfo(
+            jnp.zeros((n_dead, 1)),
+            jnp.sort(dead_loglik),  # Ensure increasing
+            dead_loglik_birth,
+            jnp.zeros(n_dead),
         )
 
         # Calculate ESS

--- a/tests/ns/test_nested_sampling.py
+++ b/tests/ns/test_nested_sampling.py
@@ -123,7 +123,7 @@ class NestedSamplingTest(chex.TestCase):
         state = base.init(positions, init_state_fn)
 
         # Mock inner kernel for testing - matches new API signature
-        def mock_inner_kernel(rng_keys, inner_state, loglikelihood_0, params):
+        def mock_inner_kernel(rng_keys, inner_state, loglikelihood_0):
             # inner_state is StateWithLogLikelihood
             # Simple random walk for testing
             def single_step(rng_key, state):


### PR DESCRIPTION
Intermediate WIP PR where we reorganise things again. Compared to external-params this moves the external pieces back into the adaptive.py setup.

I had to force push this due to lots of mypy warnings in utils so I will address those as part of this (the utils need some addressing anyway, in particular finalise)