### PR TITLE
remember to pass through `rng_key`

### DIFF
--- a/blackjax/ns/adaptive.py
+++ b/blackjax/ns/adaptive.py
@@ -59,7 +59,7 @@ def init(
     init_state_fn: Callable,
     loglikelihood_birth: float = jnp.nan,
     update_inner_kernel_params_fn: Optional[Callable] = None,
-    rng_key: Optional[jax.random.PRNGKey] = None,
+    rng_key: Optional[PRNGKey] = None,
 ) -> AdaptiveNSState:
     base_state = base_init(
         positions, init_state_fn, loglikelihood_birth=loglikelihood_birth

--- a/blackjax/ns/nss.py
+++ b/blackjax/ns/nss.py
@@ -227,6 +227,7 @@ def as_top_level_api(
             position,
             init_state_fn=jax.vmap(init_state_fn),
             update_inner_kernel_params_fn=update_inner_kernel_params_fn,
+            rng_key=rng_key,
         )
 
     def step_fn(rng_key, state):


### PR DESCRIPTION
was having a nice day until I accidentally made this with the base branch as blackjax-devs/main. Pretty brutal that PRs are forever.

Anyway, surely rng_key is supposed to be passed through here, and fixed a type hint while I was at it.