### PR TITLE
log1mexp: clamp x to -eps to keep NaN out of log_weights / sample / ess

### DIFF
--- a/blackjax/ns/utils.py
+++ b/blackjax/ns/utils.py
@@ -24,7 +24,15 @@ from blackjax.types import Array, ArrayTree, PRNGKey
 
 
 def log1mexp(x: Array) -> Array:
-    """Computes log(1 - exp(x)) in a numerically stable way."""
+    """Computes log(1 - exp(x)) in a numerically stable way.
+
+    Mathematically defined for x <= 0 only. Inputs at or slightly above 0
+    (typically a float32 cumsum-drift artifact in `logX`) would make the
+    stable branch evaluate log(-expm1(x)) = log(negative) = NaN; we clamp
+    such inputs to -eps so the result is log(eps) -- the smallest
+    representable shrinkage at the dtype's precision -- instead of NaN.
+    """
+    x = jnp.minimum(x, -jnp.finfo(x.dtype).eps)
     return jnp.where(
         x > -0.6931472,  # approx log(2)
         jnp.log(-jnp.expm1(x)),


### PR DESCRIPTION
log1mexp(x) = log(1 - exp(x)) is mathematically defined only for x <= 0; the stable branch log(-expm1(x)) returns NaN for any x > 0 (since -expm1(x) is negative). In NS post-processing this matters because logX is computed by cumsum over many small negative random shrinkages, and in float32 the cumulative round-off can make consecutive logX values cross by a hair, yielding a slightly-positive log_diff fed into log1mexp.

Clamping the input to x <= -eps fixes it at the source -- log1mexp(-eps) ~= log(eps), the smallest representable shrinkage at the dtype's precision. (Clamping at 0 gives -inf, dropping the particle entirely; clamping at log(eps) gives ~0, falsely giving the particle dX/X ~= 0.5.)

