### PR TITLE
NS: clamp log1mexp input to avoid NaN from float32 logX drift

### DIFF
--- a/blackjax/ns/utils.py
+++ b/blackjax/ns/utils.py
@@ -25,6 +25,9 @@ from blackjax.types import Array, ArrayTree, PRNGKey
 
 def log1mexp(x: Array) -> Array:
     """Computes log(1 - exp(x)) in a numerically stable way."""
+    # precision hack: clamp x <= -eps so float32 cumsum drift in logX
+    # can't push the argument positive and produce NaN downstream.
+    x = jnp.minimum(x, -jnp.finfo(x.dtype).eps)
     return jnp.where(
         x > -0.6931472,  # approx log(2)
         jnp.log(-jnp.expm1(x)),


### PR DESCRIPTION
## Summary
- Cherry-picks the `log1mexp` clamp fix from `origin/irmh` (94cf6676).
- `log1mexp(x) = log(1 - exp(x))` is defined only for `x <= 0`; float32 cumsum drift in `logX` can push the argument slightly positive, making the stable branch `log(-expm1(x))` return NaN and poisoning `log_weights` / `sample` / `ess`.
- Clamp the input to `-eps` so the result is `log(eps)` -- the smallest representable shrinkage -- instead of NaN.

## Test plan
- [ ] Existing NS tests pass (`pytest tests/ns`)
- [ ] Spot-check post-processing on a run that previously produced NaN weights at shape=500

🤖 Generated with [Claude Code](https://claude.com/claude-code)